### PR TITLE
Complete the `list` command implementation on Linux

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -41,7 +41,7 @@ public struct Linux: Platform {
             try FileManager.default.createDirectory(at: toolchainsDir, withIntermediateDirectories: false)
         }
 
-        print("Extracting toolchain...")
+        SwiftlyCore.print("Extracting toolchain...")
         let toolchainDir = toolchainsDir.appendingPathComponent(version.name)
 
         if toolchainDir.fileExists() {

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -62,10 +62,10 @@ struct Install: SwiftlyCommand {
 
     internal static func execute(version: ToolchainVersion) async throws {
         guard try !Config.load().installedToolchains.contains(version) else {
-            print("\(version) is already installed, exiting.")
+            SwiftlyCore.print("\(version) is already installed, exiting.")
             return
         }
-        print("Installing \(version)")
+        SwiftlyCore.print("Installing \(version)")
 
         let tmpFile = Swiftly.currentPlatform.getTempFilePath()
         FileManager.default.createFile(atPath: tmpFile.path, contents: nil)
@@ -133,7 +133,7 @@ struct Install: SwiftlyCommand {
                 }
             )
         } catch _ as HTTP.DownloadNotFoundError {
-            print("\(version) does not exist, exiting")
+            SwiftlyCore.print("\(version) does not exist, exiting")
             return
         } catch {
             animation.complete(success: false)
@@ -153,7 +153,7 @@ struct Install: SwiftlyCommand {
             try await Use.execute(version)
         }
 
-        print("\(version) installed successfully!")
+        SwiftlyCore.print("\(version) installed successfully!")
     }
 
     /// Utilize the GitHub API along with the provided selector to select a toolchain for install.
@@ -161,7 +161,7 @@ struct Install: SwiftlyCommand {
     func resolve(selector: ToolchainSelector) async throws -> ToolchainVersion {
         switch selector {
         case .latest:
-            print("Fetching the latest stable Swift release...")
+            SwiftlyCore.print("Fetching the latest stable Swift release...")
 
             guard let release = try await HTTP.getReleaseToolchains(limit: 1).first else {
                 throw Error(message: "couldn't get latest releases")
@@ -179,7 +179,7 @@ struct Install: SwiftlyCommand {
                 return .stable(ToolchainVersion.StableRelease(major: major, minor: minor, patch: patch))
             }
 
-            print("Fetching the latest stable Swift \(major).\(minor) release...")
+            SwiftlyCore.print("Fetching the latest stable Swift \(major).\(minor) release...")
             // If a patch was not provided, perform a lookup to get the latest patch release
             // of the provided major/minor version pair.
             let toolchain = try await HTTP.getReleaseToolchains(limit: 1) { release in
@@ -197,7 +197,7 @@ struct Install: SwiftlyCommand {
                 return ToolchainVersion(snapshotBranch: branch, date: date)
             }
 
-            print("Fetching the latest \(branch) branch snapshot...")
+            SwiftlyCore.print("Fetching the latest \(branch) branch snapshot...")
             // If a date was not provided, perform a lookup to find the most recent snapshot
             // for the given branch.
             let snapshot = try await HTTP.getSnapshotToolchains(limit: 1) { snapshot in

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -40,7 +40,7 @@ struct List: SwiftlyCommand {
 
         let config = try Config.load()
 
-        let toolchains = config.listInstalledToolchains(selector: selector)
+        let toolchains = config.listInstalledToolchains(selector: selector).sorted { $0 > $1 }
         let activeToolchain = config.inUse
 
         let printToolchain = { (toolchain: ToolchainVersion) in
@@ -48,7 +48,7 @@ struct List: SwiftlyCommand {
             if toolchain == activeToolchain {
                 message += " (in use)"
             }
-            print(message)
+            SwiftlyCore.print(message)
         }
 
         if let selector {
@@ -68,22 +68,25 @@ struct List: SwiftlyCommand {
                 modifier = "matching"
             }
 
-            let message = "installed \(modifier) toolchains"
-            print(message)
-            print(String(repeating: "-", count: message.utf8.count))
+            let message = "Installed \(modifier) toolchains"
+            SwiftlyCore.print(message)
+            SwiftlyCore.print(String(repeating: "-", count: message.utf8.count))
             for toolchain in toolchains {
                 printToolchain(toolchain)
             }
         } else {
-            print("installed release toolchains")
-            print("----------------------------")
-            for toolchain in toolchains where toolchain.isStableRelease() {
+            SwiftlyCore.print("Installed release toolchains")
+            SwiftlyCore.print("----------------------------")
+            for toolchain in toolchains {
+                guard toolchain.isStableRelease() else {
+                    continue
+                }
                 printToolchain(toolchain)
             }
 
-            print("")
-            print("installed snapshot toolchains")
-            print("-----------------------------")
+            SwiftlyCore.print("")
+            SwiftlyCore.print("Installed snapshot toolchains")
+            SwiftlyCore.print("-----------------------------")
             for toolchain in toolchains where toolchain.isSnapshot() {
                 printToolchain(toolchain)
             }

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -43,7 +43,7 @@ internal struct Use: SwiftlyCommand {
         let config = try Config.load()
 
         guard let toolchain = config.listInstalledToolchains(selector: selector).max() else {
-            print("No installed toolchains match \"\(self.toolchain)\"")
+            SwiftlyCore.print("No installed toolchains match \"\(self.toolchain)\"")
             return
         }
 
@@ -55,7 +55,7 @@ internal struct Use: SwiftlyCommand {
         let previousToolchain = config.inUse
 
         guard toolchain != previousToolchain else {
-            print("\(toolchain) is already in use")
+            SwiftlyCore.print("\(toolchain) is already in use")
             return
         }
 
@@ -68,6 +68,6 @@ internal struct Use: SwiftlyCommand {
             message += " (was \(previousToolchain))"
         }
 
-        print(message)
+        SwiftlyCore.print(message)
     }
 }

--- a/Sources/SwiftlyCore/SwiftlyCore.swift
+++ b/Sources/SwiftlyCore/SwiftlyCore.swift
@@ -44,3 +44,22 @@ public var requiredDirectories: [URL] {
         SwiftlyCore.toolchainsDir,
     ]
 }
+
+/// Protocol defining a handler for information swiftly intends to print to stdout.
+/// This is currently only used to intercept print statements for testing.
+public protocol OutputHandler {
+    func handleOutputLine(_ string: String)
+}
+
+/// The output handler to use, if any.
+public var outputHandler: (any OutputHandler)?
+
+/// Pass the provided string to the set output handler if any.
+/// If no output handler has been set, just print to stdout.
+public func print(_ string: String) {
+    guard let handler = SwiftlyCore.outputHandler else {
+        Swift.print(string)
+        return
+    }
+    handler.handleOutputLine(string)
+}

--- a/Tests/SwiftlyTests/ListTests.swift
+++ b/Tests/SwiftlyTests/ListTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+@testable import Swiftly
+@testable import SwiftlyCore
+import XCTest
+
+final class ListTests: SwiftlyTests {
+    static let homeName = "useTests"
+
+    // Below are some constants indicating which versions are installed during setup.
+
+    static let oldStable = ToolchainVersion(major: 5, minor: 6, patch: 0)
+    static let oldStableNewPatch = ToolchainVersion(major: 5, minor: 6, patch: 3)
+    static let newStable = ToolchainVersion(major: 5, minor: 7, patch: 0)
+    static let oldMainSnapshot = ToolchainVersion(snapshotBranch: .main, date: "2022-09-10")
+    static let newMainSnapshot = ToolchainVersion(snapshotBranch: .main, date: "2022-10-22")
+    static let oldReleaseSnapshot = ToolchainVersion(snapshotBranch: .release(major: 5, minor: 7), date: "2022-08-27")
+    static let newReleaseSnapshot = ToolchainVersion(snapshotBranch: .release(major: 5, minor: 7), date: "2022-08-30")
+
+    static let allToolchains: [ToolchainVersion] = [
+        ListTests.oldStable,
+        ListTests.oldStableNewPatch,
+        ListTests.newStable,
+        ListTests.oldMainSnapshot,
+        ListTests.newMainSnapshot,
+        ListTests.oldReleaseSnapshot,
+        ListTests.newReleaseSnapshot,
+    ]
+
+    static let sortedReleaseToolchains: [ToolchainVersion] = [
+        ListTests.newStable,
+        ListTests.oldStableNewPatch,
+        ListTests.oldStable
+    ]
+
+    static let sortedSnapshotToolchains: [ToolchainVersion] = [
+        ListTests.newMainSnapshot,
+        ListTests.oldMainSnapshot,
+        ListTests.newReleaseSnapshot,
+        ListTests.oldReleaseSnapshot
+    ]
+
+    /// Constructs a mock home directory with the toolchains listed above installed and runs the provided closure within
+    /// the context of that home.
+    func runListTest(f: () async throws -> Void) async throws {
+        try await self.withTestHome(name: Self.homeName) {
+            for toolchain in Self.allToolchains {
+                try self.installMockedToolchain(toolchain: toolchain)
+            }
+
+            var use = try self.parseCommand(Use.self, ["use", "latest"])
+            try await use.run()
+
+            try await f()
+        }
+    }
+
+    /// Runs a `list` command with the provided selector and parses the output to return an array of listed toolchains
+    /// in the order they were printed to stdout.
+    func runList(selector: String?) async throws -> [ToolchainVersion] {
+        var args = ["list"]
+        if let selector {
+            args.append(selector)
+        }
+
+        var list = try self.parseCommand(List.self, args)
+        let output = try await list.runWithOutput()
+
+        let parsedToolchains = output.compactMap { outputLine in
+            Self.allToolchains.first {
+                outputLine.contains(String(describing: $0))
+            }
+        }
+
+        // Ensure extra toolchains weren't accidentally included in the output.
+        guard parsedToolchains.count == output.filter({ $0.hasPrefix("Swift") || $0.contains("-snapshot") }).count else {
+            throw SwiftlyTestError(message: "unexpected listed toolchains in \(output)")
+        }
+
+        return parsedToolchains
+    }
+
+    /// Tests that running `swiftly list` without a selector prints all installed toolchains, sorted in descending
+    /// order with release toolchains listed first.
+    func testList() async throws {
+        try await self.runListTest {
+            let toolchains = try await self.runList(selector: nil)
+            XCTAssertEqual(toolchains, Self.sortedReleaseToolchains + Self.sortedSnapshotToolchains)
+        }
+    }
+
+    /// Tests that running `swiftly list` with a release version selector filters out unmatching toolchains and prints
+    /// in descending order.
+    func testListReleaseToolchains() async throws {
+        try await self.runListTest {
+            var toolchains = try await self.runList(selector: "5")
+            XCTAssertEqual(toolchains, Self.sortedReleaseToolchains)
+
+            var selector = "\(Self.newStable.asStableRelease!.major).\(Self.newStable.asStableRelease!.minor)"
+            toolchains = try await self.runList(selector: selector)
+            XCTAssertEqual(toolchains, [Self.newStable])
+
+            selector = "\(Self.oldStable.asStableRelease!.major).\(Self.oldStable.asStableRelease!.minor)"
+            toolchains = try await self.runList(selector: selector)
+            XCTAssertEqual(toolchains, [Self.oldStableNewPatch, Self.oldStable])
+
+            for toolchain in Self.sortedReleaseToolchains {
+                toolchains = try await self.runList(selector: toolchain.name)
+                XCTAssertEqual(toolchains, [toolchain])
+            }
+
+            toolchains = try await self.runList(selector: "4")
+            XCTAssertEqual(toolchains, [])
+        }
+    }
+
+    /// Tests that running `swiftly list` with a snapshot selector filters out unmatching toolchains and prints
+    /// in descending order.
+    func testListSnapshotToolchains() async throws {
+        try await self.runListTest {
+            var toolchains = try await self.runList(selector: "main-snapshot")
+            XCTAssertEqual(toolchains, [Self.newMainSnapshot, Self.oldMainSnapshot])
+
+            let snapshotBranch = Self.newReleaseSnapshot.asSnapshot!.branch
+            toolchains = try await self.runList(selector: "\(snapshotBranch.major!).\(snapshotBranch.minor!)-snapshot")
+            XCTAssertEqual(toolchains, [Self.newReleaseSnapshot, Self.oldReleaseSnapshot])
+
+            for toolchain in Self.sortedSnapshotToolchains {
+                toolchains = try await self.runList(selector: toolchain.name)
+                XCTAssertEqual(toolchains, [toolchain])
+            }
+
+            toolchains = try await self.runList(selector: "1.2-snapshot")
+            XCTAssertEqual(toolchains, [])
+        }
+    }
+
+    /// Tests that the "(in use)" marker is correctly printed when listing installed toolchains.
+    func testListInUse() async throws {
+        func inUseTest(toolchain: ToolchainVersion, selector: String?) async throws {
+            var use = try self.parseCommand(Use.self, ["use", toolchain.name])
+            try await use.run()
+
+            var listArgs = ["list"]
+            if let selector {
+                listArgs.append(selector)
+            }
+            var list = try self.parseCommand(List.self, listArgs)
+            let output = try await list.runWithOutput()
+
+            let inUse = output.filter { $0.contains("in use") }
+            XCTAssertEqual(inUse, ["\(toolchain) (in use)"])
+        }
+
+        try await self.runListTest {
+            for toolchain in Self.allToolchains {
+                try await inUseTest(toolchain: toolchain, selector: nil)
+                try await inUseTest(toolchain: toolchain, selector: toolchain.name)
+            }
+
+            let major = Self.oldStable.asStableRelease!.major
+            for toolchain in Self.sortedReleaseToolchains.filter({ $0.asStableRelease?.major == major }) {
+                try await inUseTest(toolchain: toolchain, selector: "\(major)")
+            }
+
+            for toolchain in Self.allToolchains.filter({ $0.asSnapshot?.branch == .main }) {
+                try await inUseTest(toolchain: toolchain, selector: "main-snapshot")
+            }
+
+            let branch = Self.oldReleaseSnapshot.asSnapshot!.branch
+            let releaseSnapshots = Self.allToolchains.filter {
+                $0.asSnapshot?.branch == branch
+            }
+            for toolchain in releaseSnapshots {
+                try await inUseTest(toolchain: toolchain, selector: "\(branch.major!).\(branch.minor!)-snapshot")
+            }
+        }
+    }
+
+    /// Tests that `list` properly handles the case where no toolchains been installed yet.
+    func testListEmpty() async throws {
+        try await self.withTestHome {
+            var toolchains = try await self.runList(selector: nil)
+            XCTAssertEqual(toolchains, [])
+
+            toolchains = try await self.runList(selector: "5")
+            XCTAssertEqual(toolchains, [])
+
+            toolchains = try await self.runList(selector: "main-snapshot")
+            XCTAssertEqual(toolchains, [])
+
+            toolchains = try await self.runList(selector: "5.7-snapshot")
+            XCTAssertEqual(toolchains, [])
+        }
+    }
+}

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -186,6 +186,93 @@ class SwiftlyTests: XCTestCase {
         }
 #endif
     }
+
+    /// Install a mocked toolchain associated with the given version that includes the provided list of executables
+    /// in its bin directory.
+    ///
+    /// When executed, the mocked executables will simply print the toolchain version and return.
+    func installMockedToolchain(toolchain: ToolchainVersion, executables: [String] = ["swift"]) throws {
+        let toolchainDir = SwiftlyCore.toolchainsDir.appendingPathComponent(toolchain.name)
+        try FileManager.default.createDirectory(at: toolchainDir, withIntermediateDirectories: true)
+
+        let toolchainBinDir = toolchainDir
+            .appendingPathComponent("usr", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: toolchainBinDir,
+            withIntermediateDirectories: true
+        )
+
+        // create dummy executable file that just prints the toolchain's version
+        for executable in executables {
+            let executablePath = toolchainBinDir.appendingPathComponent(executable)
+
+            let script = """
+            #!/usr/bin/env sh
+
+            echo '\(toolchain.name)'
+            """
+
+            let data = script.data(using: .utf8)!
+            try data.write(to: executablePath)
+
+            // make the file executable
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executablePath.path)
+        }
+
+        try Config.update { config in
+            config.installedToolchains.insert(toolchain)
+        }
+    }
+
+    /// Get the toolchain version of a mocked executable installed via `installMockedToolchain` at the given URL.
+    func getMockedToolchainVersion(at url: URL) throws -> ToolchainVersion {
+        let process = Process()
+        process.executableURL = url
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard let outputData = try outputPipe.fileHandleForReading.readToEnd() else {
+            throw SwiftlyTestError(message: "got no output from swift binary at path \(url.path)")
+        }
+
+        let toolchainVersion = String(decoding: outputData, as: UTF8.self).trimmingCharacters(in: .newlines)
+        return try ToolchainVersion(parsing: toolchainVersion)
+    }
+}
+
+public class TestOutputHandler: SwiftlyCore.OutputHandler {
+    public var lines: [String]
+    private let quiet: Bool
+
+    public init(quiet: Bool) {
+        self.lines = []
+        self.quiet = quiet
+    }
+
+    public func handleOutputLine(_ string: String) {
+        self.lines.append(string)
+
+        if !self.quiet {
+            Swift.print(string)
+        }
+    }
+}
+
+extension SwiftlyCommand {
+    mutating func runWithOutput(quiet: Bool = false) async throws -> [String] {
+        let handler = TestOutputHandler(quiet: quiet)
+        SwiftlyCore.outputHandler = handler
+        defer {
+            SwiftlyCore.outputHandler = nil
+        }
+        try await self.run()
+        return handler.lines
+    }
 }
 
 /// Wrapper around a `swift` executable used to execute swift commands.


### PR DESCRIPTION
Closes #6

This PR touches up the output of the `list` command (sorts it properly, capitalizes consistently) and adds some tests.