### PR TITLE
Support downloading toolchains for non-x86_64 architectures

### DIFF
--- a/Sources/Swiftly/Config.swift
+++ b/Sources/Swiftly/Config.swift
@@ -20,6 +20,9 @@ public struct Config: Codable, Equatable {
         /// output and logging.
         /// For example, “Ubuntu 18.04” would be returned on Ubuntu 18.04.
         public let namePretty: String
+
+        /// The CPU architecture of the platform. If omitted, assumed to be x86_64.
+        public let architecture: String?
     }
 
     public var inUse: ToolchainVersion?

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -76,6 +76,14 @@ struct Install: SwiftlyCommand {
         }
 
         var url = "https://download.swift.org/"
+
+        var platformString = config.platform.name
+        var platformFullString = config.platform.nameFull
+        if let arch = config.platform.architecture {
+            platformString += "-\(arch)"
+            platformFullString += "-\(arch)"
+        }
+
         switch version {
         case let .stable(stableVersion):
             // Building URL path that looks like:
@@ -84,10 +92,11 @@ struct Install: SwiftlyCommand {
             if stableVersion.patch != 0 {
                 versionString += ".\(stableVersion.patch)"
             }
+
             url += "swift-\(versionString)-release/"
-            url += "\(config.platform.name)/"
+            url += "\(platformString)/"
             url += "swift-\(versionString)-RELEASE/"
-            url += "swift-\(versionString)-RELEASE-\(config.platform.nameFull).\(Swiftly.currentPlatform.toolchainFileExtension)"
+            url += "swift-\(versionString)-RELEASE-\(platformFullString).\(Swiftly.currentPlatform.toolchainFileExtension)"
         case let .snapshot(release):
             let snapshotString: String
             switch release.branch {
@@ -99,9 +108,9 @@ struct Install: SwiftlyCommand {
                 snapshotString = "swift-DEVELOPMENT-SNAPSHOT"
             }
 
-            url += "\(config.platform.name)/"
+            url += "\(platformString)/"
             url += "\(snapshotString)-\(release.date)-a/"
-            url += "\(snapshotString)-\(release.date)-a-\(config.platform.nameFull).\(Swiftly.currentPlatform.toolchainFileExtension)"
+            url += "\(snapshotString)-\(release.date)-a-\(platformFullString).\(Swiftly.currentPlatform.toolchainFileExtension)"
         }
 
         let animation = PercentProgressAnimation(

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -80,7 +80,8 @@ class SwiftlyTests: XCTestCase {
             platform: Config.PlatformDefinition(
                 name: try getEnv("SWIFTLY_PLATFORM_NAME"),
                 nameFull: try getEnv("SWIFTLY_PLATFORM_NAME_FULL"),
-                namePretty: try getEnv("SWIFTLY_PLATFORM_NAME_PRETTY")
+                namePretty: try getEnv("SWIFTLY_PLATFORM_NAME_PRETTY"),
+                architecture: try? getEnv("SWIFTLY_PLATFORM_ARCH")
             )
         )
         try config.save()


### PR DESCRIPTION
Right now, this just means supporting ARM (aarch64).