### PR TITLE
Update usage of unsafe API, upgrade libarchive to 3.7.4, upgrade async http client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "4e45e73ff02865a9bd0426ba4c6cd8dfcb967e62e7663128dd262908109e1487",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client",
       "state" : {
-        "revision" : "fb308ee72f3d4c082a507033f94afa7395963ef3",
-        "version" : "1.21.0"
+        "revision" : "0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47",
+        "version" : "1.21.2"
       }
     },
     {
@@ -136,5 +137,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/swift-server/async-http-client", from: "1.21.0"),
+        .package(url: "https://github.com/swift-server/async-http-client", from: "1.21.2"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.6.1"),
     ],

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -11,10 +11,8 @@ public protocol HTTPRequestExecutor {
 
 /// An `HTTPRequestExecutor` backed by an `HTTPClient`.
 internal struct HTTPRequestExecutorImpl: HTTPRequestExecutor {
-    fileprivate static let client = HTTPClientWrapper()
-
     public func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse {
-        try await Self.client.inner.execute(request, timeout: timeout)
+        try await HTTPClient.shared.execute(request, timeout: timeout)
     }
 }
 
@@ -166,9 +164,7 @@ public struct SwiftlyHTTPClient {
         for try await buffer in response.body {
             receivedBytes += buffer.readableBytes
 
-            try buffer.withUnsafeReadableBytes { bufferPtr in
-                try fileHandle.write(contentsOf: bufferPtr)
-            }
+            try fileHandle.write(contentsOf: buffer.readableBytesView)
 
             let now = Date()
             if let reportProgress, lastUpdate.distance(to: now) > 0.25 || receivedBytes == expectedBytes {
@@ -182,8 +178,4 @@ public struct SwiftlyHTTPClient {
 
         try fileHandle.synchronize()
     }
-}
-
-private class HTTPClientWrapper {
-    fileprivate let inner = HTTPClient.shared
 }

--- a/scripts/install-libarchive.sh
+++ b/scripts/install-libarchive.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 # TODO detect platform
-LIBARCHIVE_VERSION=3.6.1
+LIBARCHIVE_VERSION=3.7.4
 
 mkdir /tmp/archive-build
 pushd /tmp/archive-build


### PR DESCRIPTION
Reduce the use of unsafe swift constructs in favour of ones that are memory safe. In the HTTP client remove the use of the unsafe mutable pointer in favour of direct Data conversion before writing the downloaded file to disk.

Upgrade the version of libarchive to 3.7.4 with various fixes.

Upgrade the async http client to fix an issue with decompression limits encountered with the GitHub REST API's.