### PR TITLE
macOS: Generate `config.json` in `swiftly-install.sh`

### DIFF
--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -500,6 +500,19 @@ if [ "$IS_MACOS" == "false" ]; then
 }
 EOF
     )
+else
+    JSON_OUT=$(cat <<EOF
+{
+  "platform": {
+    "name": "xcode",
+    "nameFull": "osx",
+    "namePretty": "macOS"
+  },
+  "installedToolchains": [],
+  "inUse": null
+}
+EOF
+    )
 fi
 
 PROFILE_FILE="$HOME/.profile"
@@ -654,9 +667,7 @@ esac
 
 if [[ "$detected_existing_installation" != "true" || "$overwrite_existing_intallation" == "true" ]]; then
     mkdir -p "$HOME_DIR"
-    if [ "$IS_MACOS" == "false" ]; then
-        echo "$JSON_OUT" > "$HOME_DIR/config.json"
-    fi
+    echo "$JSON_OUT" > "$HOME_DIR/config.json"
 
     # Verify the downloaded executable works. The script will exit if this fails due to errexit.
     SWIFTLY_HOME_DIR="$HOME_DIR" SWIFTLY_BIN_DIR="$BIN_DIR" "$BIN_DIR/swiftly" --version > /dev/null


### PR DESCRIPTION
Fix #136 

Currently, on macOS, no `config.json` is created by `swiftly-install.sh` and swiftly crashes when run.

This PR creates it using the values advised in https://github.com/swiftlang/swiftly/pull/121#issuecomment-2182924205

The `platform`.`architecture` key has to be explicitly absent, i.e. not even an empty string, for the correct URLs to be generated.

```
% swiftly install 5.7    

Fetching the latest stable Swift 5.7 release...
Installing Swift 5.7.3
                                              Downloading Swift 5.7.3
100% [================================================================================================]
Downloaded 963.4 MiB of 963.4 MiB
Installing package in user home directory...
installer: Package name is Swift Open Source Xcode Toolchain
installer: Installing at base path /Users/brianhenry
installer: The install was successful.
Swift 5.7.3 installed successfully!
```

Edit:
* I'm happy to write tests if necessary, but I think maybe it's more a matter of adding a macOS test environment which runs all existing tests