### PR TITLE
Integrate SwiftFormat into the swiftly project dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "942a1612e8d4b18479d16ed7518859be9ac852972e43afb2a08c65d1037a641f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -152,7 +153,16 @@
         "revision" : "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
         "version" : "0.6.1"
       }
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "c7ddb09c3381cff833106345721fc314dba49e20",
+        "version" : "0.49.18"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.6.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-        // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Sources/ Tests/`
+        // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Package.swift Plugins/ Sources/ Tests/`
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.49.18"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.6.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
         // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Sources/ Tests/`
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.49.18")),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.49.18"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.6.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
+        // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Sources/ Tests/`
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.49.18")),
     ],
     targets: [
         .executableTarget(

--- a/docker/lint.dockerfile
+++ b/docker/lint.dockerfile
@@ -5,14 +5,3 @@ RUN apt-get update && apt-get install -y locales locales-all
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-
-# tools
-RUN mkdir -p $HOME/.tools
-RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
-
-# swiftformat (until part of the toolchain)
-
-ARG swiftformat_version=0.49.18
-RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
-RUN cd $HOME/.tools/swift-format && swift build -c release
-RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/test-amazonlinux2.dockerfile
+++ b/docker/test-amazonlinux2.dockerfile
@@ -15,7 +15,3 @@ COPY ./scripts/install-libarchive.sh /
 RUN /install-libarchive.sh
 
 RUN curl -L https://swift.org/keys/all-keys.asc | gpg --import
-
-# tools
-RUN mkdir -p $HOME/.tools
-RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile

--- a/docker/test-ubi9.dockerfile
+++ b/docker/test-ubi9.dockerfile
@@ -15,7 +15,3 @@ COPY ./scripts/install-libarchive.sh /
 RUN /install-libarchive.sh
 
 RUN curl -L https://swift.org/keys/all-keys.asc | gpg --import
-
-# tools
-RUN mkdir -p $HOME/.tools
-RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile

--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -18,7 +18,3 @@ COPY ./scripts/install-libarchive.sh /
 RUN /install-libarchive.sh
 
 RUN curl -L https://swift.org/keys/all-keys.asc | gpg --import
-
-# tools
-RUN mkdir -p $HOME/.tools
-RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -2,4 +2,4 @@
 
 set -o errexit
 
-swiftformat --lint --dryrun .
+swift run swiftformat --lint --dryrun .


### PR DESCRIPTION
The SwiftFormat that is run in the CI is a very specific version that is unlikely to be the one a dev has installed with homebrew or discovered for themselves and built from source. Discovering the version involves finding the magic in the lint.dockerfile.

SwiftPM provides a mechanism for bringing in product dependencies so that you can simply run using the toolchain. The dependencies can be specified using an exact match on a particular version. These products from the dependencies can be discovered using the `swift package describe` command, and perhaps someday Swift devs will discover a package's dev tools in this way.

Add the SwiftFormat dependency as a package dependency in swiftly at the version that is currently used in the soundness CI checks. Use the the swift command to invoke the 'swiftformat' product from the dependency instead of manually git cloning and building it manually in the dockerfile.

Provide a rationale for the dependency in the Package.swift for anyone who is curious about it.