### PR TITLE
Fix GPG check randomly fails

### DIFF
--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -684,7 +684,7 @@ if [ "$IS_MACOS" == "false" ]; then
         if has_command gpg ; then
             echo ""
             echo "Importing Swift's PGP keys..."
-            curl --compressed --silent --retry 3 --location --fail https://swift.org/keys/all-keys.asc | gpg --import -
+            curl --compressed --silent --retry 3 --location --fail https://www.swift.org/keys/all-keys.asc | gpg --import -
         else
             echo "gpg not installed, skipping import of Swift's PGP keys."
         fi

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -684,7 +684,7 @@ if [ "$IS_MACOS" == "false" ]; then
         if has_command gpg ; then
             echo ""
             echo "Importing Swift's PGP keys..."
-            curl --silent --retry 3 --location --fail https://swift.org/keys/all-keys.asc | gpg --import -
+            curl --compressed --silent --retry 3 --location --fail https://swift.org/keys/all-keys.asc | gpg --import -
         else
             echo "gpg not installed, skipping import of Swift's PGP keys."
         fi


### PR DESCRIPTION
## Problem

The install script randomly fails with an error like below.

```
Importing Swift's PGP keys...
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```

## Cause

Sometimes https://www.swift.org/keys/all-keys.asc returns a gzipped response, regardless of the request header's `Accept-Encoding`.

<details>
<summary>Pattern1</summary>

```
< HTTP/1.1 200 OK
< Server: Apple
< Date: Thu, 29 Aug 2024 02:19:07 GMT
< Content-Type: text/plain; charset=UTF-8
< Content-Length: 18563
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Last-Modified: Wed, 28 Aug 2024 07:22:09 GMT
< Accept-Ranges: bytes
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=31536000; includeSubdomains
< Cache-Control: max-age=180, public
< Etag: "4883-620b9374b8a40"
< Age: 2
< Via: https/1.1 jptyo7-edge-mx-017.ts.apple.com (acdn/255.14450), https/1.1 jptyo7-edge-fx-003.ts.apple.com (acdn/255.14450)
< X-Cache: hit-stale, hit-stale
< CDNUUID: 5da39fb1-3e44-440b-ab5d-f9dbba698545-515598867
< Connection: keep-alive
< 
[plain text output]
```

</details>

<details>
<summary>Pattern2(gzipped)</summary>

```
< HTTP/1.1 200 OK
< Server: Apple
< Date: Thu, 29 Aug 2024 02:18:41 GMT
< Content-Type: text/plain; charset=UTF-8
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Last-Modified: Wed, 28 Aug 2024 07:22:09 GMT
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=31536000; includeSubdomains
< Content-Encoding: gzip
< Cache-Control: max-age=180, public
< Etag: "4883-620b9374b8a40"
< Accept-Ranges: bytes
< Age: 0
< Content-Length: 11040
< Via: https/1.1 jptyo5-edge-lx-012.ts.apple.com (acdn/255.14450), https/1.1 jptyo5-edge-bx-029.ts.apple.com (acdn/255.14450)
< X-Cache: hit-stale, miss
< CDNUUID: 0bcda0aa-252d-45af-a452-36166b9e6d17-382020025
< Connection: keep-alive
< 
[binary output]
```

</details>

## How to fix

Simply add the `--compressed` options to the curl command.
This option allows curl to handle gzipped bodies transparently.

## Reference

- https://github.com/swift-actions/setup-swift/pull/680