### PR TITLE
Fix package install detection for packages that are partially installed

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -164,11 +164,11 @@ public struct Linux: Platform {
 
         let manager: String? = switch platformName {
         case "ubuntu1804":
-            "apt"
+            "apt-get"
         case "ubuntu2004":
-            "apt"
+            "apt-get"
         case "ubuntu2204":
-            "apt"
+            "apt-get"
         case "amazonlinux2":
             "yum"
         case "ubi9":
@@ -216,21 +216,38 @@ public struct Linux: Platform {
             return nil
         }
 
-        let missingPackages = packages.filter { !self.isSystemPackageInstalled(manager, $0) }.joined(separator: " ")
+        var missingPackages: [String] = []
+
+        for pkg in packages {
+            if case let pkgInstalled = await self.isSystemPackageInstalled(manager, pkg), !pkgInstalled {
+                missingPackages.append(pkg)
+            }
+        }
 
         guard !missingPackages.isEmpty else {
             return nil
         }
 
-        return "\(manager) -y install \(missingPackages)"
+        return "\(manager) -y install \(missingPackages.joined(separator: " "))"
     }
 
-    public func isSystemPackageInstalled(_ manager: String?, _ package: String) -> Bool {
+    public func isSystemPackageInstalled(_ manager: String?, _ package: String) async -> Bool {
         do {
             switch manager {
-            case "apt":
-                try self.runProgram("dpkg", "-l", package, quiet: true)
-                return true
+            case "apt-get":
+                if let pkgList = try await self.runProgramOutput("dpkg", "-l", package) {
+                    // The package might be listed but not in an installed non-error state.
+                    //
+                    // Look for something like this:
+                    //
+                    //   Desired=Unknown/Install/Remove/Purge/Hold
+                    //   | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+                    //   |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+                    //   ||/
+                    //   ii  pkgfoo         1.0.0ubuntu12        My description goes here....
+                    return pkgList.contains("\nii ")
+                }
+                return false
             case "yum":
                 try self.runProgram("yum", "list", "installed", package, quiet: true)
                 return true


### PR DESCRIPTION
On Debian/Ubuntu Linux that use the dpkg/apt package manager there is a possibility that a package is not in a fully installed state. It can be removed, leaving its configuration files, or the install could have failed. Check rigorously that the package is fully installed without error before producing the command-line.

Also, correct the install command to use apt-get instead of apt since that command-line is guaranteed to be stable.