### PR TITLE
Add a single swift test to help the macOS CI to complete without error

### DIFF
--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -8,10 +8,16 @@ import XCTest
 
 #if os(macOS)
 import MacOSPlatform
+import Testing
 #endif
 
 import AsyncHTTPClient
 import NIO
+
+#if os(macOS)
+@Test("help ci builds to pass on macOS")
+func ci_pass() {}
+#endif
 
 struct SwiftlyTestError: LocalizedError {
     let message: String


### PR DESCRIPTION
The macOS CI is currently failing with what appears to be a bug in SwiftPM where it fails when there XCTests, but not Swift Tests. Add a trivial Swift Test to help the macOS CI to report as green when all of the XCTests pass.