### PR TITLE
Verify the libarchive payload

### DIFF
--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -322,7 +322,8 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         try runProgram(curl, "-o", "\(buildCheckoutsDir + "/libarchive-\(libArchiveVersion).tar.gz")", "--remote-name", "--location", "https://github.com/libarchive/libarchive/releases/download/v\(libArchiveVersion)/libarchive-\(libArchiveVersion).tar.gz")
         let libArchiveTarShaActual = try await runProgramOutput(sha256sum, "\(buildCheckoutsDir)/libarchive-\(libArchiveVersion).tar.gz")
         guard let libArchiveTarShaActual, libArchiveTarShaActual.starts(with: libArchiveTarSha) else {
-            throw Error(message: "The libarchive tar.gz file sha256sum is \(libArchiveTarShaActual), but expected \(libArchiveTarSha)")
+            let shaActual = libArchiveTarShaActual ?? "none"
+            throw Error(message: "The libarchive tar.gz file sha256sum is \(shaActual), but expected \(libArchiveTarSha)")
         }
         try runProgram(tar, "--directory=\(buildCheckoutsDir)", "-xzf", "\(buildCheckoutsDir)/libarchive-\(libArchiveVersion).tar.gz")
 

--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -298,13 +298,19 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         let make = try await self.assertTool("make", message: "Please install make with `yum install make`")
         let git = try await self.assertTool("git", message: "Please install git with `yum install git`")
         let strip = try await self.assertTool("strip", message: "Please install strip with `yum install binutils`")
+        let sha256sum = try await self.assertTool("sha256sum", message: "Please install sha256sum with `yum install coreutils`")
 
         let swift = try await self.checkSwiftRequirement()
 
         try await self.checkGitRepoStatus(git)
 
-        // Build a specific version of libarchive
+        // Start with a fresh SwiftPM package
+        try runProgram(swift, "package", "reset")
+
+        // Build a specific version of libarchive with a check on the tarball's SHA256
         let libArchiveVersion = "3.7.4"
+        let libArchiveTarSha = "7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8"
+
         let buildCheckoutsDir = FileManager.default.currentDirectoryPath + "/.build/checkouts"
         let libArchivePath = buildCheckoutsDir + "/libarchive-\(libArchiveVersion)"
         let pkgConfigPath = libArchivePath + "/pkgconfig"
@@ -314,6 +320,10 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 
         try? FileManager.default.removeItem(atPath: libArchivePath)
         try runProgram(curl, "-o", "\(buildCheckoutsDir + "/libarchive-\(libArchiveVersion).tar.gz")", "--remote-name", "--location", "https://github.com/libarchive/libarchive/releases/download/v\(libArchiveVersion)/libarchive-\(libArchiveVersion).tar.gz")
+        let libArchiveTarShaActual = try await runProgramOutput(sha256sum, "\(buildCheckoutsDir)/libarchive-\(libArchiveVersion).tar.gz")
+        guard let libArchiveTarShaActual, libArchiveTarShaActual.starts(with: libArchiveTarSha) else {
+            throw Error(message: "The libarchive tar.gz file sha256sum is \(libArchiveTarShaActual), but expected \(libArchiveTarSha)")
+        }
         try runProgram(tar, "--directory=\(buildCheckoutsDir)", "-xzf", "\(buildCheckoutsDir)/libarchive-\(libArchiveVersion).tar.gz")
 
         let cwd = FileManager.default.currentDirectoryPath
@@ -349,8 +359,6 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         try runProgram(make, "install")
 
         FileManager.default.changeCurrentDirectoryPath(cwd)
-
-        try runProgram(swift, "package", "clean")
 
         // Statically link standard libraries for maximum portability of the swiftly binary
         try runProgram(swift, "build", "--product=swiftly", "--pkg-config-path=\(pkgConfigPath)/lib/pkgconfig", "--static-swift-stdlib", "--configuration=release")


### PR DESCRIPTION
The libarchive that is used to make a swiftly release for Linux is downloaded directly from the libarchive project on GitHub from a release artifact. In theory, this release could become tampered in the future.

Typically package managers get around this problem by both getting a specific version of the package, and also keep a hash/git commit to verify the contents.

Add a content check using an expected SHA-256 sum of the release source tarball of libarchive to help protect against any tampering of the release in the future.