### PR TITLE
Add documentation related build and checks to GitHub workflows

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Upload Release Artifact
         uses: actions/upload-artifact@v4
         with:
+          name: swiftly-release-x86_64
           path: .build/release/swiftly-*.tar.gz
           if-no-files-found: error
       - name: Build Documentation Artifacts
@@ -35,5 +36,6 @@ jobs:
       - name: Upload Documentation Artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: swiftly-docs
           path: .build/docs/**
           if-no-files-found: error

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -23,10 +23,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Build Artifact
+      - name: Build Release Artifact
         run: swift run build-swiftly-release ${{ inputs.skip }} ${{ inputs.version }}
-      - name: Upload Artifact
+      - name: Upload Release Artifact
         uses: actions/upload-artifact@v4
         with:
           path: .build/release/swiftly-*.tar.gz
+          if-no-files-found: error
+      - name: Build Documentation Artifacts
+        run: swift package --allow-writing-to-directory .build/docs generate-documentation --target SwiftlyDocs --output-path .build/docs
+      - name: Upload Documentation Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: .build/docs/**
           if-no-files-found: error

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,3 +57,24 @@ jobs:
       linux_pre_build_command: ./scripts/prep-gh-action.sh
       linux_build_command: swift run swiftformat --lint --dryrun .
       enable_windows_checks: false
+
+  docscheck:
+    name: Documentation Check
+    runs-on: ubuntu-latest
+    container:
+      image: "swift:6.0-noble"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Prepare the action
+        run: ./scripts/prep-gh-action.sh && ./scripts/install-libarchive.sh
+      - name: Generate Swiftly CLI Reference and Check for Differences
+        run: swift package plugin --allow-writing-to-package-directory generate-docs-reference && git diff-index --quiet HEAD --  || (echo "The documentation hasn't been updated with the latest swiftly command-line reference. Please run 'swift package plugin generate-docs-reference' and commit/push the changes."; exit 1)
+      - name: Generate Documentation Set
+        run: swift package --allow-writing-to-directory .build/docs generate-documentation --target SwiftlyDocs --output-path .build/docs
+      - name: Upload Documentation Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: .build/docs/**
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
+          name: swiftly-release-x86_64
           path: .build/release/swiftly-*.tar.gz
           if-no-files-found: error
           retention-days: 1
@@ -75,6 +76,7 @@ jobs:
       - name: Upload Documentation Artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: swiftly-docs
           path: .build/docs/**
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Prepare the action
         run: ./scripts/prep-gh-action.sh && ./scripts/install-libarchive.sh
       - name: Generate Swiftly CLI Reference and Check for Differences
-        run: swift package plugin --allow-writing-to-package-directory generate-docs-reference && git diff-index --quiet HEAD --  || (echo "The documentation hasn't been updated with the latest swiftly command-line reference. Please run 'swift package plugin generate-docs-reference' and commit/push the changes."; exit 1)
+        run: swift package plugin --allow-writing-to-package-directory generate-docs-reference && git config --global --add safe.directory $(pwd) && git diff-index --quiet HEAD --  || (echo "The documentation hasn't been updated with the latest swiftly command-line reference. Please run 'swift package plugin generate-docs-reference' and commit/push the changes."; exit 1)
       - name: Generate Documentation Set
         run: swift package --allow-writing-to-directory .build/docs generate-documentation --target SwiftlyDocs --output-path .build/docs
       - name: Upload Documentation Artifacts

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Prepare the action
         run: ./scripts/prep-gh-action.sh && ./scripts/install-libarchive.sh
       - name: Generate Swiftly CLI Reference and Check for Differences
-        run: swift package plugin --allow-writing-to-package-directory generate-docs-reference && git config --global --add safe.directory $(pwd) && git diff-index --quiet HEAD --  || (echo "The documentation hasn't been updated with the latest swiftly command-line reference. Please run 'swift package plugin generate-docs-reference' and commit/push the changes."; exit 1)
+        run: swift package plugin --allow-writing-to-package-directory generate-docs-reference && git config --global --add safe.directory $(pwd) && git diff --exit-code Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md || (echo "The documentation hasn't been updated with the latest swiftly command-line reference. Please run 'swift package plugin generate-docs-reference' and commit/push the changes."; exit 1)
       - name: Generate Documentation Set
         run: swift package --allow-writing-to-directory .build/docs generate-documentation --target SwiftlyDocs --output-path .build/docs
       - name: Upload Documentation Artifacts

--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -1,4 +1,4 @@
-# swiftly 
+# swiftly
 
 <!-- THIS FILE HAS BEEN GENERATED using the following command: swift package plugin generate-docs-reference -->
 

--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -1,4 +1,4 @@
-# swiftly
+# swiftly 
 
 <!-- THIS FILE HAS BEEN GENERATED using the following command: swift package plugin generate-docs-reference -->
 


### PR DESCRIPTION
There's nothing in the pull request verification that checks if the command-line references are up-to-date. Add a job to the pull request update workflow that verifies this.

There's nothing in the release build workflow that generates the documentation and uploads the documentation artifacts so that they can be published. Add a step to the build release job that generates the documentation so that it can be published to swift.org.