### PR TITLE
Download toolchains using proxy if one is set in the environment

### DIFF
--- a/Documentation/SwiftlyDocs.docc/getting-started.md
+++ b/Documentation/SwiftlyDocs.docc/getting-started.md
@@ -58,6 +58,17 @@ Uninstall this toolchain after you're finished with it:
 $ swiftly uninstall main-snapshot
 ```
 
+# Proxy
+
+Swiftly downloads a list of toolchains from https://www.swift.org/ and retrieves them from Apple/Akamai CDN via https://download.swift.org.
+If your environment requires a proxy, Swiftly will attempt to use the standard environment variables `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY` to determine which proxy server to use instead of making a direct connection.
+
+To download latest nightly snapshot using a proxy:
+```
+$ export https_proxy=http://proxy:3128
+$ swiftly install main-snapshot
+```
+
 # See Also:
 
 - [Install Toolchains](install-toolchains)

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -10,7 +10,7 @@ public protocol HTTPRequestExecutor {
 }
 
 /// An `HTTPRequestExecutor` backed by the shared `HTTPClient`.
-internal struct HTTPRequestExecutorImpl: HTTPRequestExecutor {
+internal class HTTPRequestExecutorImpl: HTTPRequestExecutor {
     let httpClient: HTTPClient
 
     public init() {
@@ -22,7 +22,8 @@ internal struct HTTPRequestExecutorImpl: HTTPRequestExecutor {
                 if let proxyString = environment[key],
                    let url = URL(string: proxyString),
                    let host = url.host,
-                   let port = url.port {
+                   let port = url.port
+                {
                     return .server(host: host, port: port)
                 }
             }
@@ -43,8 +44,14 @@ internal struct HTTPRequestExecutorImpl: HTTPRequestExecutor {
         }
     }
 
+    deinit {
+        if httpClient !== HTTPClient.shared {
+            try? httpClient.syncShutdown()
+        }
+    }
+
     public func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse {
-        try await httpClient.execute(request, timeout: timeout)
+        try await self.httpClient.execute(request, timeout: timeout)
     }
 }
 

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -11,8 +11,40 @@ public protocol HTTPRequestExecutor {
 
 /// An `HTTPRequestExecutor` backed by the shared `HTTPClient`.
 internal struct HTTPRequestExecutorImpl: HTTPRequestExecutor {
+    let httpClient: HTTPClient
+
+    public init() {
+        var proxy: HTTPClient.Configuration.Proxy?
+
+        func getProxyFromEnv(keys: [String]) -> HTTPClient.Configuration.Proxy? {
+            let environment = ProcessInfo.processInfo.environment
+            for key in keys {
+                if let proxyString = environment[key],
+                   let url = URL(string: proxyString),
+                   let host = url.host,
+                   let port = url.port {
+                    return .server(host: host, port: port)
+                }
+            }
+            return nil
+        }
+
+        if let httpProxy = getProxyFromEnv(keys: ["http_proxy", "HTTP_PROXY"]) {
+            proxy = httpProxy
+        }
+        if let httpsProxy = getProxyFromEnv(keys: ["https_proxy", "HTTPS_PROXY"]) {
+            proxy = httpsProxy
+        }
+
+        if proxy != nil {
+            self.httpClient = HTTPClient(eventLoopGroupProvider: .singleton, configuration: HTTPClient.Configuration(proxy: proxy))
+        } else {
+            self.httpClient = HTTPClient.shared
+        }
+    }
+
     public func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse {
-        try await HTTPClient.shared.execute(request, timeout: timeout)
+        try await httpClient.execute(request, timeout: timeout)
     }
 }
 


### PR DESCRIPTION
Read http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY standard environment variables; and set `HTTPClient()` proxy configuration with one of the values.

Fixes https://github.com/swiftlang/swiftly/issues/108

@cmcgee1024 - this adds the minimal silent use based on the environment. Most tools read one of those variables.