### PR TITLE
Remove unnecessary C++ library package install from GH prep script

### DIFF
--- a/scripts/prep-gh-action.sh
+++ b/scripts/prep-gh-action.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# This script does a bit of extra preparation of the docker containers used to run the GitHub workflows
+# that are specific to this project's needs when building/testing. Note that this script runs on
+# every supported Linux distribution so it must adapt to the distribution that it is running.
+
 apt-get --help && apt-get update && apt-get -y install curl make
 yum --help && (curl --help && yum -y install curl) && yum install make
 
-(cat /etc/os-release | grep bookworm) && apt-get -y install libstdc++-12-dev gnupg2
-(cat /etc/os-release | grep 'Fedora Linux 39') && yum -y install libstdc++-devel libstdc++-static
+(cat /etc/os-release | grep bookworm) && apt-get -y install gnupg2
 
 exit 0


### PR DESCRIPTION
These packages needed to be installed in some of the Linux distributions because the swift docker container images didn't include them, even though they are required to compile any C++ code. The docker images should be updated now and so these extra steps are no longer needed.