### PR TITLE
Make release package file names more uname friendly on Linux

### DIFF
--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -374,7 +374,7 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 #if arch(arm64)
         let releaseArchive = "\(releaseDir)/swiftly-\(version)-aarch64.tar.gz"
 #else
-        let releaseArchive = "\(releaseDir)/swiftly-\(version).tar.gz"
+        let releaseArchive = "\(releaseDir)/swiftly-\(version)-x86_64.tar.gz"
 #endif
 
         try runProgram(tar, "--directory=\(releaseDir)", "-czf", releaseArchive, "swiftly", "LICENSE.txt")


### PR DESCRIPTION
When operating on Linux there are different variants of swiftly for either x86_64 or aarch64 architectures. It is likely that people will need to make platform-independent samples, such as on swift.org to download the correct binary package for their system. By making the filename reflect what `uname -m` on the system scripts can use this to make sure that they download the correct release package and also they can download both without collisions. Fix the release package filename for linux x86_64 to include the architecture in the file name so that the filename matches the following:

`swiftly-<VERSION>-$(uname -m).tar.gz`