### PR TITLE
Conform Swiftly's Error type to CustomStringConvertible

### DIFF
--- a/Sources/SwiftlyCore/Error.swift
+++ b/Sources/SwiftlyCore/Error.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-public struct Error: LocalizedError {
+public struct Error: LocalizedError, CustomStringConvertible {
     public let message: String
 
     public init(message: String) {
         self.message = message
     }
 
-    public var errorDescription: String? { self.message }
+    public var errorDescription: String { self.message }
+    public var description: String { self.message }
 }

--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -12,14 +12,15 @@ public struct SwiftRelease: Codable {
 }
 
 // These functions are cloned and adapted from SwiftlyCore until we can do better bootstrapping
-public struct Error: LocalizedError {
+public struct Error: LocalizedError, CustomStringConvertible {
     public let message: String
 
     public init(message: String) {
         self.message = message
     }
 
-    public var errorDescription: String? { self.message }
+    public var errorDescription: String { self.message }
+    public var description: String { self.message }
 }
 
 public func runProgramEnv(_ args: String..., quiet: Bool = false, env: [String: String]?) throws {


### PR DESCRIPTION
`swift-argument-parser` will use an Error's description when printing the error. This patch conforms Swiftly's Error type to CustomStringConvertible, which will show the actual message in stdout instead of the object's description of `Error(message: "...")`

Issue: #201