### PR TITLE
Fix typo

### DIFF
--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -72,7 +72,7 @@ Likewise, the latest snapshot associated with a given development branch can be 
 
 *A file path to a location for a post installation script*
 
-If the toolchain that is installed has extra post installation steps they they will be
+If the toolchain that is installed has extra post installation steps, they will be
 written to this file as commands that can be run after the installation.
 
 

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -56,7 +56,7 @@ struct Install: SwiftlyCommand {
     @Option(help: ArgumentHelp(
         "A file path to a location for a post installation script",
         discussion: """
-        If the toolchain that is installed has extra post installation steps they they will be
+        If the toolchain that is installed has extra post installation steps, they will be
         written to this file as commands that can be run after the installation.
         """
     ))


### PR DESCRIPTION
I found what seems to be a typo in the description of the install subcommand and have corrected it.