### PR TITLE
Add --no-import-pgp-keys to long options for getopt

### DIFF
--- a/swiftly-install.sh
+++ b/swiftly-install.sh
@@ -339,7 +339,7 @@ set -o errexit
 shopt -s extglob
 
 short_options='yhvp:'
-long_options='disable-confirmation,no-modify-profile,no-install-system-deps,help,version,platform:,overwrite'
+long_options='disable-confirmation,no-modify-profile,no-install-system-deps,no-import-pgp-keys,help,version,platform:,overwrite'
 
 args=$(getopt --options "$short_options" --longoptions "$long_options" --name "swiftly-install" -- "${@}")
 eval "set -- ${args}"


### PR DESCRIPTION
The `--no-import-pgp-keys` option was not being passed to `getopt`, causing use of the flag to fail with `swiftly-install: unrecognized option '--no-import-pgp-keys'`.