### PR TITLE
Add a global variable cpuArch

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -7,15 +7,15 @@ var swiftGPGKeysRefreshed = false
 /// This implementation can be reused for any supported Linux platform.
 /// TODO: replace dummy implementations
 public struct Linux: Platform {
-    let linuxPlatforms = [
-        PlatformDefinition.ubuntu2404,
-        PlatformDefinition.ubuntu2204,
-        PlatformDefinition.ubuntu2004,
-        PlatformDefinition.ubuntu1804,
-        PlatformDefinition.fedora39,
-        PlatformDefinition.rhel9,
-        PlatformDefinition.amazonlinux2,
-        PlatformDefinition.debian12,
+    let linuxPlatforms: [PlatformDefinition] = [
+        .ubuntu2404,
+        .ubuntu2204,
+        .ubuntu2004,
+        .ubuntu1804,
+        .fedora39,
+        .rhel9,
+        .amazonlinux2,
+        .debian12,
     ]
 
     public init() {}
@@ -510,7 +510,7 @@ public struct Linux: Platform {
                 return await self.manualSelectPlatform(platformPretty)
             }
 
-            return PlatformDefinition.amazonlinux2
+            return .amazonlinux2
         } else if (id + (idlike ?? "")).contains("rhel") {
             guard versionID.hasPrefix("9") else {
                 let message = "Unsupported version of RHEL"
@@ -522,7 +522,7 @@ public struct Linux: Platform {
                 return await self.manualSelectPlatform(platformPretty)
             }
 
-            return PlatformDefinition.rhel9
+            return .rhel9
         } else if let pd = [PlatformDefinition.ubuntu1804, .ubuntu2004, .ubuntu2204, .ubuntu2404, .debian12, .fedora39].first(where: { $0.name == id + versionID }) {
             return pd
         }

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -382,13 +382,7 @@ public struct Linux: Platform {
     }
 
     public func getExecutableName() -> String {
-#if arch(x86_64)
-        let arch = "x86_64"
-#elseif arch(arm64)
-        let arch = "aarch64"
-#else
-        fatalError("Unsupported processor architecture")
-#endif
+        let arch = cpuArch
 
         return "swiftly-\(arch)-unknown-linux-gnu"
     }

--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -156,7 +156,7 @@ public struct MacOS: Platform {
 
     public func detectPlatform(disableConfirmation _: Bool, platform _: String?) async -> PlatformDefinition {
         // No special detection required on macOS platform
-        PlatformDefinition.macOS
+        .macOS
     }
 
     public func getShell() async throws -> String {

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -295,17 +295,7 @@ public struct SwiftlyHTTPClient {
         limit: Int? = nil,
         filter: ((ToolchainVersion.StableRelease) -> Bool)? = nil
     ) async throws -> [ToolchainVersion.StableRelease] {
-        let arch = if a == nil {
-#if arch(x86_64)
-            "x86_64"
-#elseif arch(arm64)
-            "aarch64"
-#else
-            #error("Unsupported processor architecture")
-#endif
-        } else {
-            a!
-        }
+        let arch = a ?? cpuArch
 
         let url = "https://www.swift.org/api/v1/install/releases.json"
         let swiftOrgReleases: [SwiftOrgRelease] = try await self.getFromJSON(url: url, type: [SwiftOrgRelease].self)
@@ -359,17 +349,7 @@ public struct SwiftlyHTTPClient {
         limit: Int? = nil,
         filter: ((ToolchainVersion.Snapshot) -> Bool)? = nil
     ) async throws -> [ToolchainVersion.Snapshot] {
-        let arch = if a == nil {
-#if arch(x86_64)
-            "x86_64"
-#elseif arch(arm64)
-            "aarch64"
-#else
-            #error("Unsupported processor architecture")
-#endif
-        } else {
-            a!
-        }
+        let arch = a ?? cpuArch
 
         let platformName = if platform.name == PlatformDefinition.macOS.name {
             "macos"

--- a/Sources/SwiftlyCore/SwiftlyCore.swift
+++ b/Sources/SwiftlyCore/SwiftlyCore.swift
@@ -51,3 +51,11 @@ public func readLine(prompt: String) -> String? {
     }
     return provider.readLine()
 }
+
+#if arch(x86_64)
+    public let cpuArch = "x86_64"
+#elseif arch(arm64)
+    public let cpuArch = "aarch64"
+#else
+    #error("Unsupported processor architecture")
+#endif

--- a/Sources/SwiftlyCore/SwiftlyCore.swift
+++ b/Sources/SwiftlyCore/SwiftlyCore.swift
@@ -53,9 +53,9 @@ public func readLine(prompt: String) -> String? {
 }
 
 #if arch(x86_64)
-    public let cpuArch = "x86_64"
+public let cpuArch = "x86_64"
 #elseif arch(arm64)
-    public let cpuArch = "aarch64"
+public let cpuArch = "aarch64"
 #else
-    #error("Unsupported processor architecture")
+#error("Unsupported processor architecture")
 #endif

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -51,27 +51,27 @@ final class HTTPClientTests: SwiftlyTests {
     }
 
     func testGetToolchainMetdataFromSwiftOrg() async throws {
-        let supportedPlatforms = [
-            PlatformDefinition.macOS,
-            PlatformDefinition.ubuntu2404,
-            PlatformDefinition.ubuntu2204,
-            PlatformDefinition.ubuntu2004,
-            // PlatformDefinition.ubuntu1804, // There are no releases for Ubuntu 18.04 in the branches being tested below
-            PlatformDefinition.rhel9,
-            PlatformDefinition.fedora39,
-            PlatformDefinition.amazonlinux2,
-            PlatformDefinition.debian12,
+        let supportedPlatforms: [PlatformDefinition] = [
+            .macOS,
+            .ubuntu2404,
+            .ubuntu2204,
+            .ubuntu2004,
+            // .ubuntu1804, // There are no releases for Ubuntu 18.04 in the branches being tested below
+            .rhel9,
+            .fedora39,
+            .amazonlinux2,
+            .debian12,
         ]
 
-        let newPlatforms = [
-            PlatformDefinition.ubuntu2404,
-            PlatformDefinition.fedora39,
-            PlatformDefinition.debian12,
+        let newPlatforms: [PlatformDefinition] = [
+            .ubuntu2404,
+            .fedora39,
+            .debian12,
         ]
 
-        let branches = [
-            ToolchainVersion.Snapshot.Branch.main,
-            ToolchainVersion.Snapshot.Branch.release(major: 6, minor: 0), // This is available in swift.org API
+        let branches: [ToolchainVersion.Snapshot.Branch] = [
+            .main,
+            .release(major: 6, minor: 0), // This is available in swift.org API
         ]
 
         for arch in ["x86_64", "aarch64"] {

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -331,10 +331,10 @@ class SwiftlyTests: XCTestCase {
 
         // Snapshots are currently unavailable for these platforms on swift.org
         // TODO: remove these once snapshots are available for them
-        let snapshotsUnavailable = [
-            PlatformDefinition.ubuntu2404,
-            PlatformDefinition.fedora39,
-            PlatformDefinition.debian12,
+        let snapshotsUnavailable: [PlatformDefinition] = [
+            .ubuntu2404,
+            .fedora39,
+            .debian12,
         ]
 
         return !snapshotsUnavailable.contains(pd)


### PR DESCRIPTION
- Move arch string literal to a global variable `cpuArch`.
- Refactor: Let compiler to infer the array type.