### PR TITLE
Consistency in y/n prompts #141 fix

### DIFF
--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -76,8 +76,7 @@ internal struct Init: SwiftlyCommand {
             These locations can be changed with SWIFTLY_HOME and SWIFTLY_BIN environment variables and run this again.
             \(installMsg)
             """)
-
-            if SwiftlyCore.readLine(prompt: "Proceed with the installation? [Y/n] ") == "n" {
+            guard SwiftlyCore.promptForConfirmation(defaultBehavior: true) else {
                 throw SwiftlyError(message: "Swiftly installation has been cancelled")
             }
         }
@@ -93,9 +92,7 @@ internal struct Init: SwiftlyCommand {
                 SwiftlyCore.print("  \(swiftlyBinDir.appendingPathComponent(executable).path)")
             }
 
-            let proceed = SwiftlyCore.readLine(prompt: "Proceed? [y/N]") ?? "n"
-
-            guard proceed == "y" else {
+            guard SwiftlyCore.promptForConfirmation(defaultBehavior: false) else {
                 throw SwiftlyError(message: "Swiftly installation has been cancelled")
             }
         }
@@ -203,8 +200,10 @@ internal struct Init: SwiftlyCommand {
                     try FileManager.default.createDirectory(at: confDir, withIntermediateDirectories: true)
                     profileHome = confDir.appendingPathComponent("swiftly.fish", isDirectory: false)
                 } else {
-                    let confDir = userHome.appendingPathComponent(".config/fish/conf.d", isDirectory: true)
-                    try FileManager.default.createDirectory(at: confDir, withIntermediateDirectories: true)
+                    let confDir = userHome.appendingPathComponent(
+                        ".config/fish/conf.d", isDirectory: true)
+                    try FileManager.default.createDirectory(
+                        at: confDir, withIntermediateDirectories: true)
                     profileHome = confDir.appendingPathComponent("swiftly.fish", isDirectory: false)
                 }
             } else {

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -266,9 +266,7 @@ struct Install: SwiftlyCommand {
                     SwiftlyCore.print("  \(swiftlyBinDir.appendingPathComponent(executable).path)")
                 }
 
-                let proceed = SwiftlyCore.readLine(prompt: "Proceed? [y/N]") ?? "n"
-
-                guard proceed == "y" else {
+                guard SwiftlyCore.promptForConfirmation(defaultBehavior: false) else {
                     throw SwiftlyError(message: "Toolchain installation has been cancelled")
                 }
             }


### PR DESCRIPTION
Changed certain prompts for consistency reasons
Motivation:

Certain prompts would only accept 'y' instead of 'Y', while others accepted both these options. This fix ensures consistency when prompting users
Modifications:

Simply changed certain prompts and utilizing the promptForConfirmation method
Result:

More consistent user experience when answering prompts