### PR TITLE
Make "swift-" prefix optional in MainSnapshotParser

### DIFF
--- a/Sources/SwiftlyCore/ToolchainVersion.swift
+++ b/Sources/SwiftlyCore/ToolchainVersion.swift
@@ -411,17 +411,17 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
     }
 }
 
-/// Parser for selectors like the following:
+/// Parser for selectors like the following (with optional "swift-" prefix):
 ///    - main-snapshot-YYYY-mm-dd
 ///    - main-snapshot
 ///    - main-SNAPSHOT-YYYY-mm-dd
 ///    - main-SNAPSHOT
-///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
-///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
-///    - swift-DEVELOPMENT-SNAPSHOT
+///    - DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
+///    - DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
+///    - DEVELOPMENT-SNAPSHOT
 struct MainSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring?)> =
-        try! Regex("^(?:main-snapshot|swift-DEVELOPMENT-SNAPSHOT|main-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
+        try! Regex("^(?:swift-)?(?:main-snapshot|DEVELOPMENT-SNAPSHOT|main-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
 
     func parse(_ input: String) throws -> ToolchainSelector? {
         guard let match = try Self.regex.wholeMatch(in: input) else {

--- a/Sources/SwiftlyCore/ToolchainVersion.swift
+++ b/Sources/SwiftlyCore/ToolchainVersion.swift
@@ -383,14 +383,21 @@ struct StableReleaseParser: ToolchainSelectorParser {
     }
 }
 
-/// Parser for selectors like the following (with optional "swift-" prefix):
+/// Parser for selectors like the following:
 ///    - a.b-snapshot-YYYY-mm-dd
 ///    - a.b-snapshot
+///    - a.b-SNAPSHOT-YYYY-mm-dd
+///    - a.b-SNAPSHOT
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - a.b-DEVELOPMENT-SNAPSHOT
-///    - a.b-SNAPSHOT-YYYY-mm-dd
-///    - a.b-SNAPSHOT
+///    - swift-a.b-snapshot-YYYY-mm-dd
+///    - swift-a.b-snapshot
+///    - swift-a.b-SNAPSHOT-YYYY-mm-dd
+///    - swift-a.b-SNAPSHOT
+///    - swift-a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
+///    - swift-a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
+///    - swift-a.b-DEVELOPMENT-SNAPSHOT
 struct ReleaseSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring, Substring, Substring?)> =
         try! Regex("^(?:swift-)?([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
@@ -411,7 +418,7 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
     }
 }
 
-/// Parser for selectors like the following (with optional "swift-" prefix):
+/// Parser for selectors like the following:
 ///    - main-snapshot-YYYY-mm-dd
 ///    - main-snapshot
 ///    - main-SNAPSHOT-YYYY-mm-dd
@@ -419,6 +426,13 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
 ///    - DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - DEVELOPMENT-SNAPSHOT
+///    - swift-main-snapshot-YYYY-mm-dd
+///    - swift-main-snapshot
+///    - swift-main-SNAPSHOT-YYYY-mm-dd
+///    - swift-main-SNAPSHOT
+///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
+///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
+///    - swift-DEVELOPMENT-SNAPSHOT
 struct MainSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring?)> =
         try! Regex("^(?:swift-)?(?:main-snapshot|DEVELOPMENT-SNAPSHOT|main-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")

--- a/Tests/SwiftlyTests/ToolchainSelectorTests.swift
+++ b/Tests/SwiftlyTests/ToolchainSelectorTests.swift
@@ -34,6 +34,7 @@ final class ToolchainSelectorTests: SwiftlyTests {
             "main-SNAPSHOT-2023-06-05",
             "swift-DEVELOPMENT-SNAPSHOT-2023-06-05",
             "swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+            "DEVELOPMENT-SNAPSHOT-2023-06-05-a",
         ]
         try runTest(.snapshot(branch: .main, date: "2023-06-05"), parses)
     }


### PR DESCRIPTION
Existing tools like `swiftenv` use `DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a` for main snapshots, without the `swift-` prefix. The `MainSnapshotParser` should be able to handle this and this change mirrors the `ReleaseSnapshotParser` in this regard, which already supports both `swift-` prefixed and unprefixed versions.