### PR TITLE
Print file URLs without leading file schema

### DIFF
--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -128,11 +128,11 @@ public struct MacOS: Platform {
         let decoder = PropertyListDecoder()
         let infoPlist = toolchainDir.appendingPathComponent("Info.plist")
         guard let data = try? Data(contentsOf: infoPlist) else {
-            throw SwiftlyError(message: "could not open \(infoPlist)")
+            throw SwiftlyError(message: "could not open \(infoPlist.path)")
         }
 
         guard let pkgInfo = try? decoder.decode(SwiftPkgInfo.self, from: data) else {
-            throw SwiftlyError(message: "could not decode plist at \(infoPlist)")
+            throw SwiftlyError(message: "could not decode plist at \(infoPlist.path)")
         }
 
         try FileManager.default.removeItem(at: toolchainDir)

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -116,7 +116,7 @@ internal struct Use: SwiftlyCommand {
             // We don't care in this case if there were any problems with the swift version files, just overwrite it with the new value
             try toolchain.name.write(to: versionFile, atomically: true, encoding: .utf8)
 
-            message = "The file `\(versionFile)` has been set to `\(toolchain)`"
+            message = "The file `\(versionFile.path)` has been set to `\(toolchain)`"
         } else if let newVersionFile = findNewVersionFile(), !globalDefault {
             if !assumeYes {
                 SwiftlyCore.print("A new file `\(newVersionFile)` will be created to set the new in-use toolchain for this project. Alternatively, you can set your default globally with the `--global-default` flag. Proceed with creating this file?")
@@ -129,7 +129,7 @@ internal struct Use: SwiftlyCommand {
 
             try toolchain.name.write(to: newVersionFile, atomically: true, encoding: .utf8)
 
-            message = "The file `\(newVersionFile)` has been set to `\(toolchain)`"
+            message = "The file `\(newVersionFile.path)` has been set to `\(toolchain)`"
         } else {
             config.inUse = toolchain
             try config.save()


### PR DESCRIPTION
Swiftly interpolates some file URLs directly into user facing output leading to messages like 'The file `file:///Volumes/...` has been...' which needlessly contains the url schema prefix `file://`. This change updates Swiftly to use URL.path for better user output.