### PR TITLE
Remove rehashing instructions when using the fish shell

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -205,7 +205,7 @@ public struct Linux: Platform {
             ]
         case "debian12":
             [
-                "binutils-gold",
+                "binutils",
                 "libicu-dev",
                 "libcurl4-openssl-dev",
                 "libedit-dev",
@@ -398,7 +398,10 @@ public struct Linux: Platform {
     }
 
     public func verifySignature(httpClient: SwiftlyHTTPClient, archiveDownloadURL: URL, archive: URL, verbose: Bool) async throws {
-        SwiftlyCore.print("Downloading toolchain signature...")
+        if verbose {
+            SwiftlyCore.print("Downloading toolchain signature...")
+        }
+
         let sigFile = self.getTempFilePath()
         let _ = FileManager.default.createFile(atPath: sigFile.path, contents: nil)
         defer {

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -78,7 +78,7 @@ internal struct Init: SwiftlyCommand {
             """)
 
             guard SwiftlyCore.promptForConfirmation(defaultBehavior: true) else {
-                throw SwiftlyError(message: "Swiftly installation has been cancelled")
+                throw SwiftlyError(message: "swiftly installation has been cancelled")
             }
         }
 
@@ -242,7 +242,8 @@ internal struct Init: SwiftlyCommand {
                 """)
             }
 
-            if pathChanged {
+            // Fish doesn't have path caching, so this might only be needed for bash/zsh
+            if pathChanged && !shell.hasSuffix("fish") {
                 SwiftlyCore.print("""
                 Your shell caches items on your path for better performance. Swiftly has added items to your path that may not get picked up right away. You can run this command to update your shell to get these items.
 

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -103,7 +103,14 @@ struct Install: SwiftlyCommand {
             assumeYes: self.root.assumeYes
         )
 
-        if pathChanged {
+        let shell = if let s = ProcessInfo.processInfo.environment["SHELL"] {
+            s
+        } else {
+            try await Swiftly.currentPlatform.getShell()
+        }
+
+        // Fish doesn't cache its path, so this instruction is not necessary.
+        if pathChanged && !shell.hasSuffix("fish") {
             SwiftlyCore.print("""
             NOTE: We have updated some elements in your path and your shell may not yet be
             aware of the changes. You can run this command to update your shell.
@@ -271,7 +278,9 @@ struct Install: SwiftlyCommand {
                 }
             }
 
-            SwiftlyCore.print("Setting up toolchain proxies...")
+            if verbose {
+                SwiftlyCore.print("Setting up toolchain proxies...")
+            }
 
             let proxiesToCreate = Set(toolchainBinDirContents).subtracting(swiftlyBinDirContents).union(overwrite)
 

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -133,7 +133,7 @@ internal struct Use: SwiftlyCommand {
         } else {
             config.inUse = toolchain
             try config.save()
-            message = "The global default toolchain has set to `\(toolchain)`"
+            message = "The global default toolchain has been set to `\(toolchain)`"
         }
 
         if let selectedVersion = selectedVersion {


### PR DESCRIPTION
Change Debian 12 binutils-gold virtual package to binutils

Move some progress indications under verbose flag for shorter default install log