### PR TITLE
feature: Omit internal access control, if let shorthand, fix typos

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -223,7 +223,7 @@ To use the latest installed main snapshot, leave off the date:
 
 `swiftly use main-snapshot`
 
-The use subcommand also supports `.swift-version` files. If a ".swift-version" file is present in the current working directory, or an ancestory directory, then swiftly will update that file with the new version to use. This can be a useful feature for a team to share and align on toolchain versions with git. As a special case, if swiftly could not find a version file, but it could find a Package.swift file it will create a new version file for you in the package and set that to the requested toolchain version.
+The use subcommand also supports `.swift-version` files. If a ".swift-version" file is present in the current working directory, or an ancestry directory, then swiftly will update that file with the new version to use. This can be a useful feature for a team to share and align on toolchain versions with git. As a special case, if swiftly could not find a version file, but it could find a Package.swift file it will create a new version file for you in the package and set that to the requested toolchain version.
 
 Note: The `.swift-version` file mechanisms can be overridden using the `--global-default` flag so that your swiftly installation's default toolchain can be set explicitly.
 

--- a/Documentation/SwiftlyDocs.docc/automated-install.md
+++ b/Documentation/SwiftlyDocs.docc/automated-install.md
@@ -34,7 +34,7 @@ To begin using installed swiftly from your current shell, first run the followin
 . "/root/.local/share/swiftly/env.sh"
 ```
 
-> Note: on macOS systems you may need to run 'hash -r' to recalcuate the zsh PATH cache when installing swiftly and toolchains.
+> Note: on macOS systems you may need to run 'hash -r' to recalculate the zsh PATH cache when installing swiftly and toolchains.
 
 You can go ahead and add this command to the list of commands in your build script so that the build can proceed to call swiftly from the path. The usual next step is to install a specific swift toolchain like this:
 

--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -123,7 +123,7 @@ Likewise, the available toolchains associated with a given minor version can be 
 
     $ swiftly list-available 5.2
 
-The installed snapshots for a given devlopment branch can be listed by specifying the branch as the selector:
+The installed snapshots for a given development branch can be listed by specifying the branch as the selector:
 
     $ swiftly list-available main-snapshot
     $ swiftly list-available x.y-snapshot
@@ -301,7 +301,7 @@ Likewise, the installed toolchains associated with a given minor version can be 
 
     $ swiftly list 5.2
 
-The installed snapshots for a given devlopment branch can be listed by specifying the branch as the selector:
+The installed snapshots for a given development branch can be listed by specifying the branch as the selector:
 
     $ swiftly list main-snapshot
     $ swiftly list 5.7-snapshot
@@ -522,7 +522,7 @@ If the command that you are running needs the arguments with the '+' prefixes th
 
     $ swiftly run ./myscript.sh ++abcde
 
-The script will receive the argument as '+abcde'. If there are multiple arguments with the '+' prefix that should be escaped you can disable the selection using a '++' argument, which turns off any selector argument processing for subsequent arguments. This is anologous to the '--' that turns off flag and option processing for subsequent arguments in many argument parsers.
+The script will receive the argument as '+abcde'. If there are multiple arguments with the '+' prefix that should be escaped you can disable the selection using a '++' argument, which turns off any selector argument processing for subsequent arguments. This is analogous to the '--' that turns off flag and option processing for subsequent arguments in many argument parsers.
 
     $ swiftly run ./myscript.sh ++ +abcde +xyz
 

--- a/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
@@ -10,7 +10,7 @@ If you have a released version that you want to uninstall then give the exact th
 $ swiftly uninstall 5.6.1
 ```
 
-When you're done working with every patch of a minor swift release you can remove them all by omiting the patch version.
+When you're done working with every patch of a minor swift release you can remove them all by omitting the patch version.
 
 ```
 $ swiftly uninstall 5.6

--- a/Sources/LinuxPlatform/Extract.swift
+++ b/Sources/LinuxPlatform/Extract.swift
@@ -44,7 +44,7 @@ func copyData(readArchive: OpaquePointer?, writeArchive: OpaquePointer?) throws 
 /// the provided closure which will return the path the file will be written to.
 ///
 /// This uses libarchive under the hood, so a wide variety of archive formats are supported (e.g. .tar.gz).
-internal func extractArchive(atPath archivePath: URL, transform: (String) -> URL) throws {
+func extractArchive(atPath archivePath: URL, transform: (String) -> URL) throws {
     var flags = Int32(0)
     flags = ARCHIVE_EXTRACT_TIME
     flags |= ARCHIVE_EXTRACT_PERM

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -248,7 +248,7 @@ public struct Linux: Platform {
         if requireSignatureValidation {
             guard (try? self.runProgram("gpg", "--version", quiet: true)) != nil else {
                 var msg = "gpg is not installed. "
-                if let manager = manager {
+                if let manager {
                     msg += """
                     You can install it by running this command as root:
                         \(manager) -y install gpg
@@ -416,7 +416,7 @@ public struct Linux: Platform {
     }
 
     private func manualSelectPlatform(_ platformPretty: String?) async -> PlatformDefinition {
-        if let platformPretty = platformPretty {
+        if let platformPretty {
             print("\(platformPretty) is not an officially supported platform, but the toolchains for another platform may still work on it.")
         } else {
             print("This platform could not be detected, but a toolchain for one of the supported platforms may work on it.")

--- a/Sources/Swiftly/Config.swift
+++ b/Sources/Swiftly/Config.swift
@@ -11,7 +11,7 @@ public struct Config: Codable, Equatable {
     public var platform: PlatformDefinition
     public var version: SwiftlyVersion?
 
-    internal init(inUse: ToolchainVersion?, installedToolchains: Set<ToolchainVersion>, platform: PlatformDefinition) {
+    init(inUse: ToolchainVersion?, installedToolchains: Set<ToolchainVersion>, platform: PlatformDefinition) {
         self.inUse = inUse
         self.installedToolchains = installedToolchains
         self.platform = platform

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import SwiftlyCore
 
-internal struct Init: SwiftlyCommand {
+struct Init: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Perform swiftly initialization into your user account."
     )
@@ -29,12 +29,12 @@ internal struct Init: SwiftlyCommand {
 
     public mutating func validate() throws {}
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try await Self.execute(assumeYes: self.root.assumeYes, noModifyProfile: self.noModifyProfile, overwrite: self.overwrite, platform: self.platform, verbose: self.root.verbose, skipInstall: self.skipInstall, quietShellFollowup: self.quietShellFollowup)
     }
 
     /// Initialize the installation of swiftly.
-    internal static func execute(assumeYes: Bool, noModifyProfile: Bool, overwrite: Bool, platform: String?, verbose: Bool, skipInstall: Bool, quietShellFollowup: Bool) async throws {
+    static func execute(assumeYes: Bool, noModifyProfile: Bool, overwrite: Bool, platform: String?, verbose: Bool, skipInstall: Bool, quietShellFollowup: Bool) async throws {
         try Swiftly.currentPlatform.verifySwiftlySystemPrerequisites()
 
         var config = try? Config.load()

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -25,7 +25,7 @@ struct List: SwiftlyCommand {
 
             $ swiftly list 5.2
 
-        The installed snapshots for a given devlopment branch can be listed by specifying the branch as the selector:
+        The installed snapshots for a given development branch can be listed by specifying the branch as the selector:
 
             $ swiftly list main-snapshot
             $ swiftly list 5.7-snapshot
@@ -33,7 +33,7 @@ struct List: SwiftlyCommand {
     ))
     var toolchainSelector: String?
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try validateSwiftly()
         let selector = try self.toolchainSelector.map { input in
             try ToolchainSelector(parsing: input)
@@ -46,7 +46,7 @@ struct List: SwiftlyCommand {
 
         let printToolchain = { (toolchain: ToolchainVersion) in
             var message = "\(toolchain)"
-            if let inUse = inUse, toolchain == inUse {
+            if let inUse, toolchain == inUse {
                 message += " (in use)"
             }
             if toolchain == config.inUse {
@@ -56,20 +56,19 @@ struct List: SwiftlyCommand {
         }
 
         if let selector {
-            let modifier: String
-            switch selector {
+            let modifier = switch selector {
             case let .stable(major, minor, nil):
                 if let minor {
-                    modifier = "Swift \(major).\(minor) release"
+                    "Swift \(major).\(minor) release"
                 } else {
-                    modifier = "Swift \(major) release"
+                    "Swift \(major) release"
                 }
             case .snapshot(.main, nil):
-                modifier = "main development snapshot"
+                "main development snapshot"
             case let .snapshot(.release(major, minor), nil):
-                modifier = "\(major).\(minor) development snapshot"
+                "\(major).\(minor) development snapshot"
             default:
-                modifier = "matching"
+                "matching"
             }
 
             let message = "Installed \(modifier) toolchains"

--- a/Sources/Swiftly/ListAvailable.swift
+++ b/Sources/Swiftly/ListAvailable.swift
@@ -25,7 +25,7 @@ struct ListAvailable: SwiftlyCommand {
 
             $ swiftly list-available 5.2
 
-        The installed snapshots for a given devlopment branch can be listed by specifying the branch as the selector:
+        The installed snapshots for a given development branch can be listed by specifying the branch as the selector:
 
             $ swiftly list-available main-snapshot
             $ swiftly list-available x.y-snapshot
@@ -39,7 +39,7 @@ struct ListAvailable: SwiftlyCommand {
         case toolchainSelector
     }
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try validateSwiftly()
         let selector = try self.toolchainSelector.map { input in
             try ToolchainSelector(parsing: input)
@@ -80,20 +80,19 @@ struct ListAvailable: SwiftlyCommand {
         }
 
         if let selector {
-            let modifier: String
-            switch selector {
+            let modifier = switch selector {
             case let .stable(major, minor, nil):
                 if let minor {
-                    modifier = "Swift \(major).\(minor) release"
+                    "Swift \(major).\(minor) release"
                 } else {
-                    modifier = "Swift \(major) release"
+                    "Swift \(major) release"
                 }
             case .snapshot(.main, nil):
-                modifier = "main development snapshot"
+                "main development snapshot"
             case let .snapshot(.release(major, minor), nil):
-                modifier = "\(major).\(minor) development snapshot"
+                "\(major).\(minor) development snapshot"
             default:
-                modifier = "matching"
+                "matching"
             }
 
             let message = "Available \(modifier) toolchains"

--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import SwiftlyCore
 
-internal struct Run: SwiftlyCommand {
+struct Run: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Run a command while proxying to the selected toolchain commands."
     )
@@ -43,7 +43,7 @@ internal struct Run: SwiftlyCommand {
 
         The script will receive the argument as '+abcde'. If there are multiple arguments with the '+' prefix \
         that should be escaped you can disable the selection using a '++' argument, which turns off any \
-        selector argument processing for subsequent arguments. This is anologous to the '--' that turns off \
+        selector argument processing for subsequent arguments. This is analogous to the '--' that turns off \
         flag and option processing for subsequent arguments in many argument parsers.
 
             $ swiftly run ./myscript.sh ++ +abcde +xyz
@@ -53,7 +53,7 @@ internal struct Run: SwiftlyCommand {
     ))
     var command: [String]
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try validateSwiftly()
 
         // Handle the specific case where help is requested of the run subcommand
@@ -67,9 +67,9 @@ internal struct Run: SwiftlyCommand {
 
         let toolchain: ToolchainVersion?
 
-        if let selector = selector {
+        if let selector {
             let matchedToolchain = config.listInstalledToolchains(selector: selector).max()
-            guard let matchedToolchain = matchedToolchain else {
+            guard let matchedToolchain else {
                 throw SwiftlyError(message: "The selected toolchain \(selector.description) didn't match any of the installed toolchains. You can install it with `swiftly install \(selector.description)`")
             }
 
@@ -78,14 +78,14 @@ internal struct Run: SwiftlyCommand {
             let (version, result) = try await selectToolchain(config: &config)
 
             // Abort on any errors relating to swift version files
-            if case let .swiftVersionFile(_, _, error) = result, let error = error {
+            if case let .swiftVersionFile(_, _, error) = result, let error {
                 throw error
             }
 
             toolchain = version
         }
 
-        guard let toolchain = toolchain else {
+        guard let toolchain else {
             throw SwiftlyError(message: "No installed swift toolchain is selected from either from a .swift-version file, or the default. You can try using one that's already installed with `swiftly use <toolchain version>` or install a new toolchain to use with `swiftly install --use <toolchain version>`.")
         }
 

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -5,7 +5,7 @@ import TSCUtility
 
 import SwiftlyCore
 
-internal struct SelfUpdate: SwiftlyCommand {
+struct SelfUpdate: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Update the version of swiftly itself."
     )
@@ -16,7 +16,7 @@ internal struct SelfUpdate: SwiftlyCommand {
         case root
     }
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try validateSwiftly()
 
         let swiftlyBin = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent("swiftly")

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -49,9 +49,9 @@ public struct Swiftly: SwiftlyCommand {
     public init() {}
 
 #if os(Linux)
-    internal static let currentPlatform = Linux.currentPlatform
+    static let currentPlatform = Linux.currentPlatform
 #elseif os(macOS)
-    internal static let currentPlatform = MacOS.currentPlatform
+    static let currentPlatform = MacOS.currentPlatform
 #endif
 }
 

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -120,7 +120,7 @@ struct Update: SwiftlyCommand {
         try await Uninstall.execute(parameters.oldToolchain, &config, verbose: self.root.verbose)
         SwiftlyCore.print("Successfully updated \(parameters.oldToolchain) ⟶ \(newToolchain)")
 
-        if let postInstallScript = postInstallScript {
+        if let postInstallScript {
             guard let postInstallFile = self.postInstallFile else {
                 throw SwiftlyError(message: """
 

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import SwiftlyCore
 
-internal struct Use: SwiftlyCommand {
+struct Use: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Set the in-use or default toolchain. If no toolchain is provided, print the currently in-use toolchain, if any."
     )
@@ -54,7 +54,7 @@ internal struct Use: SwiftlyCommand {
     ))
     var toolchain: String?
 
-    internal mutating func run() async throws {
+    mutating func run() async throws {
         try validateSwiftly()
         var config = try Config.load()
 
@@ -63,11 +63,11 @@ internal struct Use: SwiftlyCommand {
             let (selectedVersion, result) = try await selectToolchain(config: &config, globalDefault: self.globalDefault)
 
             // Abort on any errors with the swift version files
-            if case let .swiftVersionFile(_, _, error) = result, let error = error {
+            if case let .swiftVersionFile(_, _, error) = result, let error {
                 throw error
             }
 
-            guard let selectedVersion = selectedVersion else {
+            guard let selectedVersion else {
                 // Return with nothing if there's no toolchain that is selected
                 return
             }
@@ -107,7 +107,7 @@ internal struct Use: SwiftlyCommand {
     }
 
     /// Use a toolchain. This method can modify and save the input config and also create/modify a `.swift-version` file.
-    internal static func execute(_ toolchain: ToolchainVersion, globalDefault: Bool, assumeYes: Bool = true, _ config: inout Config) async throws {
+    static func execute(_ toolchain: ToolchainVersion, globalDefault: Bool, assumeYes: Bool = true, _ config: inout Config) async throws {
         let (selectedVersion, result) = try await selectToolchain(config: &config, globalDefault: globalDefault)
 
         var message: String
@@ -136,14 +136,14 @@ internal struct Use: SwiftlyCommand {
             message = "The global default toolchain has been set to `\(toolchain)`"
         }
 
-        if let selectedVersion = selectedVersion {
+        if let selectedVersion {
             message += " (was \(selectedVersion.name))"
         }
 
         SwiftlyCore.print(message)
     }
 
-    internal static func findNewVersionFile() -> URL? {
+    static func findNewVersionFile() -> URL? {
         var cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
         while cwd.path != "" && cwd.path != "/" {
@@ -203,7 +203,7 @@ public func selectToolchain(config: inout Config, globalDefault: Bool = false) a
             if FileManager.default.fileExists(atPath: svFile.path) {
                 let contents = try? String(contentsOf: svFile, encoding: .utf8)
 
-                guard let contents = contents else {
+                guard let contents else {
                     return (nil, .swiftVersionFile(svFile, nil, SwiftlyError(message: "The swift version file could not be read: \(svFile)")))
                 }
 
@@ -219,7 +219,7 @@ public func selectToolchain(config: inout Config, globalDefault: Bool = false) a
                     return (nil, .swiftVersionFile(svFile, nil, SwiftlyError(message: "The swift version file is malformed: \(svFile) \(error)")))
                 }
 
-                guard let selector = selector else {
+                guard let selector else {
                     return (nil, .swiftVersionFile(svFile, nil, SwiftlyError(message: "The swift version file is malformed: \(svFile)")))
                 }
 

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -55,7 +55,7 @@ public protocol HTTPRequestExecutor {
     func getCurrentSwiftlyRelease() async throws -> Components.Schemas.SwiftlyRelease
 }
 
-internal struct SwiftlyUserAgentMiddleware: ClientMiddleware {
+struct SwiftlyUserAgentMiddleware: ClientMiddleware {
     package func intercept(
         _ request: HTTPRequest,
         body: HTTPBody?,
@@ -71,7 +71,7 @@ internal struct SwiftlyUserAgentMiddleware: ClientMiddleware {
 }
 
 /// An `HTTPRequestExecutor` backed by the shared `HTTPClient`.
-internal class HTTPRequestExecutorImpl: HTTPRequestExecutor {
+class HTTPRequestExecutorImpl: HTTPRequestExecutor {
     let httpClient: HTTPClient
 
     public init() {
@@ -215,7 +215,7 @@ public struct SwiftOrgSnapshot: Codable {
     private static let snapshotRegex: Regex<(Substring, Substring?, Substring?, Substring)> =
         try! Regex("swift(?:-(\\d+)\\.(\\d+))?-DEVELOPMENT-SNAPSHOT-(\\d{4}-\\d{2}-\\d{2})")
 
-    internal func parseSnapshot() throws -> ToolchainVersion.Snapshot? {
+    func parseSnapshot() throws -> ToolchainVersion.Snapshot? {
         guard let match = try? Self.snapshotRegex.firstMatch(in: self.dir) else {
             return nil
         }
@@ -329,7 +329,7 @@ public struct SwiftlyHTTPClient {
 
         swiftOrgFiltered.sort(by: >)
 
-        return if let limit = limit {
+        return if let limit {
             Array(swiftOrgFiltered.prefix(limit))
         } else {
             swiftOrgFiltered
@@ -393,7 +393,7 @@ public struct SwiftlyHTTPClient {
 
         matchingSnapshots.sort(by: >)
 
-        return if let limit = limit {
+        return if let limit {
             Array(matchingSnapshots.prefix(limit))
         } else {
             matchingSnapshots

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -139,7 +139,7 @@ extension Platform {
     }
 
 #if os(macOS) || os(Linux)
-    internal func proxyEnv(_ toolchain: ToolchainVersion) throws -> [String: String] {
+    func proxyEnv(_ toolchain: ToolchainVersion) throws -> [String: String] {
         let tcPath = self.findToolchainLocation(toolchain).appendingPathComponent("usr/bin")
         guard tcPath.fileExists() else {
             throw SwiftlyError(message: "Toolchain \(toolchain) could not be located. You can try `swiftly uninstall \(toolchain)` to uninstall it and then `swiftly install \(toolchain)` to install it again.")
@@ -197,7 +197,7 @@ extension Platform {
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = args
 
-        if let env = env {
+        if let env {
             process.environment = env
         }
 
@@ -243,7 +243,7 @@ extension Platform {
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [program] + args
 
-        if let env = env {
+        if let env {
             process.environment = env
         }
 
@@ -270,7 +270,7 @@ extension Platform {
             throw RunProgramError(exitCode: process.terminationStatus, program: args.first!)
         }
 
-        if let outData = outData {
+        if let outData {
             return String(data: outData, encoding: .utf8)
         } else {
             return nil

--- a/Tests/SwiftlyTests/E2ETests.swift
+++ b/Tests/SwiftlyTests/E2ETests.swift
@@ -27,16 +27,15 @@ final class E2ETests: SwiftlyTests {
             XCTAssertEqual(SwiftlyCore.version, config.version)
 
             // Check the environment script, if the shell is supported
-            let envScript: URL?
-            if shell.hasSuffix("bash") || shell.hasSuffix("zsh") {
-                envScript = Swiftly.currentPlatform.swiftlyHomeDir.appendingPathComponent("env.sh")
+            let envScript: URL? = if shell.hasSuffix("bash") || shell.hasSuffix("zsh") {
+                Swiftly.currentPlatform.swiftlyHomeDir.appendingPathComponent("env.sh")
             } else if shell.hasSuffix("fish") {
-                envScript = Swiftly.currentPlatform.swiftlyHomeDir.appendingPathComponent("env.fish")
+                Swiftly.currentPlatform.swiftlyHomeDir.appendingPathComponent("env.fish")
             } else {
-                envScript = nil
+                nil
             }
 
-            if let envScript = envScript {
+            if let envScript {
                 XCTAssertTrue(envScript.fileExists())
             }
 
@@ -53,7 +52,7 @@ final class E2ETests: SwiftlyTests {
             let installedToolchain = config.installedToolchains.first!
 
             guard case let .stable(release) = installedToolchain else {
-                XCTFail("expected swiftly install latest to insall release toolchain but got \(installedToolchain)")
+                XCTFail("expected swiftly install latest to install release toolchain but got \(installedToolchain)")
                 return
             }
 

--- a/Tests/SwiftlyTests/InitTests.swift
+++ b/Tests/SwiftlyTests/InitTests.swift
@@ -22,7 +22,7 @@ final class InitTests: SwiftlyTests {
                 envScript = nil
             }
 
-            if let envScript = envScript {
+            if let envScript {
                 XCTAssertFalse(envScript.fileExists())
             }
 
@@ -35,7 +35,7 @@ final class InitTests: SwiftlyTests {
             XCTAssertEqual(SwiftlyCore.version, config.version)
 
             // AND: it creates an environment script suited for the type of shell
-            if let envScript = envScript {
+            if let envScript {
                 XCTAssertTrue(envScript.fileExists())
                 if let scriptContents = try? String(contentsOf: envScript) {
                     XCTAssertTrue(scriptContents.contains("SWIFTLY_HOME_DIR"))
@@ -46,7 +46,7 @@ final class InitTests: SwiftlyTests {
             }
 
             // AND: it sources the script from the user profile
-            if let envScript = envScript {
+            if let envScript {
                 var foundSourceLine = false
                 for p in [".profile", ".zprofile", ".bash_profile", ".bash_login", ".config/fish/conf.d/swiftly.fish"] {
                     let profile = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(p)

--- a/Tests/SwiftlyTests/InstallTests.swift
+++ b/Tests/SwiftlyTests/InstallTests.swift
@@ -25,7 +25,7 @@ final class InstallTests: SwiftlyTests {
                 let installedToolchain = config.installedToolchains.first!
 
                 guard case let .stable(release) = installedToolchain else {
-                    XCTFail("expected swiftly install latest to insall release toolchain but got \(installedToolchain)")
+                    XCTFail("expected swiftly install latest to install release toolchain but got \(installedToolchain)")
                     return
                 }
 
@@ -55,14 +55,14 @@ final class InstallTests: SwiftlyTests {
                 let config = try Config.load()
 
                 guard !config.installedToolchains.isEmpty else {
-                    XCTFail("expected swiftly install latest to insall release toolchain but installed toolchains is empty in config")
+                    XCTFail("expected swiftly install latest to install release toolchain but installed toolchains is empty in config")
                     return
                 }
 
                 let installedToolchain = config.installedToolchains.first!
 
                 guard case let .stable(release) = installedToolchain else {
-                    XCTFail("expected swiftly install latest to insall release toolchain but got \(installedToolchain)")
+                    XCTFail("expected swiftly install latest to install release toolchain but got \(installedToolchain)")
                     return
                 }
 

--- a/Tests/SwiftlyTests/UpdateTests.swift
+++ b/Tests/SwiftlyTests/UpdateTests.swift
@@ -39,7 +39,7 @@ final class UpdateTests: SwiftlyTests {
         }
     }
 
-    /// Verify that updating the lastest installed toolchain updates it to the latest available toolchain.
+    /// Verify that updating the latest installed toolchain updates it to the latest available toolchain.
     func testUpdateLatestToLatest() async throws {
         try await self.withTestHome {
             try await self.withMockedToolchain {
@@ -59,7 +59,7 @@ final class UpdateTests: SwiftlyTests {
         }
     }
 
-    /// Verify that the latest installed toolchain for a given major version can be updated to the lastest
+    /// Verify that the latest installed toolchain for a given major version can be updated to the latest
     /// released minor version.
     func testUpdateToLatestMinor() async throws {
         try await self.withTestHome {

--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -103,7 +103,7 @@ public func runProgramOutput(_ program: String, _ args: String...) async throws 
         throw Error(message: "\(args.first!) exited with non-zero status: \(process.terminationStatus)")
     }
 
-    if let outData = outData {
+    if let outData {
         return String(data: outData, encoding: .utf8)
     } else {
         return nil
@@ -203,7 +203,7 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 
             if FileManager.default.fileExists(atPath: svFile.path) {
                 let selector = try? String(contentsOf: svFile, encoding: .utf8)
-                if let selector = selector {
+                if let selector {
                     return selector.replacingOccurrences(of: "\n", with: "")
                 }
                 return selector


### PR DESCRIPTION
- Omitted `internal` access control because of no need in explicit declaration as it is default
- Following SE-0345 refactored if let constructions
- Fixed typos
- Some general code enhancements