### PR TITLE
Update the abstracts for the HowTo guides, Rename HOWTOS to Guides

### DIFF
--- a/Documentation/SwiftlyDocs.docc/SwiftlyDocs.md
+++ b/Documentation/SwiftlyDocs.docc/SwiftlyDocs.md
@@ -10,7 +10,7 @@ Install and manage your Swift programming language toolchains.
 
 - <doc:getting-started>
 
-### HOWTOS
+### Guides
 
 - <doc:install-toolchains>
 - <doc:use-toolchains>

--- a/Documentation/SwiftlyDocs.docc/automated-install.md
+++ b/Documentation/SwiftlyDocs.docc/automated-install.md
@@ -1,8 +1,9 @@
 # Install Swiftly Automatically
 
-Swiftly can be installed automatically in places like build/CI systems.
+Automatically install swiftly and Swift toolchains.
 
-This guide will help you to script to the installation of swiftly and toolchains so that it can be unattended. We assume that you have working understanding of your build system. The examples are based on a typical Unix environment.
+This guide helps you to automate the installation of swiftly and toolchains so that it can run unattended, for example in build or continous integration systems.
+We assume that you have working understanding of your build system. The examples are based on a typical Unix environment.
 
 First, download the swiftly binary from swift.org for your operating system (e.g. Linux) and processor architecture (e.g. arm64, or x86_64). Here's an example using the popular curl command.
 

--- a/Documentation/SwiftlyDocs.docc/install-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/install-toolchains.md
@@ -1,6 +1,6 @@
 # Install Swift Toolchains
 
-swiftly install
+Install swift toolchains with Swiftly.
 
 Installing a swift toolchain using swiftly involves downloading it securely and extracting it into a well-known location in your account. Here we will guide you through the different ways you can install a swift toolchain. You will need to install swiftly first. The [Getting Started](getting-started.md) guide is a good place to start with swiftly.
 

--- a/Documentation/SwiftlyDocs.docc/shell-autocompletion.md
+++ b/Documentation/SwiftlyDocs.docc/shell-autocompletion.md
@@ -1,5 +1,7 @@
 # Add Shell Auto-completions
 
+Generate shell auto-completions for Swiftly.
+
 Swiftly can generate shell auto-completion scripts for your shell to automatically complete subcommands, arguments, options and flags. It does this using the [swift-argument-parser](https://apple.github.io/swift-argument-parser/documentation/argumentparser/installingcompletionscripts/), which has support for Bash, Z shell, and Fish.
 
 You can ask swiftly to generate the script using the hidden `--generate-completion-script` flag with the type of shell like this:

--- a/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
@@ -1,6 +1,6 @@
 # Uninstall Swift Toolchains
 
-swiftly uninstall
+Uninstall Swift toolchains.
 
 After installing several toolchains the list of the available toolchains to use becomes too large. Each toolchain also occupies substantial storage space. It's good to be able to cleanup toolchains when they aren't needed anymore. This guide will cover how to uninstall your toolchains assuming that you have installed swiftly and used it to install them.
 

--- a/Documentation/SwiftlyDocs.docc/update-toolchain.md
+++ b/Documentation/SwiftlyDocs.docc/update-toolchain.md
@@ -1,6 +1,6 @@
 # Update Swift Toolchain
 
-swiftly update
+Update swift toolchains.
 
 Update replaces a given toolchain with a later version of that toolchain. For a stable release, this means updating to a later patch, minor, or major version. For snapshots, this means updating to the most recently available snapshot. Swiftly can help you to keep up-to-date. We assume that you have installed swiftly and use it to manage your toolchains.
 

--- a/Documentation/SwiftlyDocs.docc/use-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/use-toolchains.md
@@ -1,6 +1,6 @@
 # Use Swift Toolchains
 
-swiftly use and swiftly run
+Using installed swift toolchains.
 
 Swiftly toolchains include a variety of compilers, linkers, debuggers, documentation generators, and other useful tools for working with Swift. Using a toolchain activates it so that when you run toolchain commands they are run with that version.
 


### PR DESCRIPTION
Updates the abstracts for each of the HowTo guides, and renames the topic heading from 'HOWTOS' to 'Guides'.