### PR TITLE
Add ability to temporarily unlink swiftly

### DIFF
--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -545,3 +545,81 @@ The script will receive the argument '+abcde' followed by '+xyz'.
 
 
 
+## link
+
+Link swiftly so it resumes management of the active toolchain.
+
+```
+swiftly link [<toolchain-selector>] [--assume-yes] [--verbose] [--version] [--help]
+```
+
+**toolchain-selector:**
+
+*Links swiftly if it has been disabled.*
+
+
+Links swiftly if it has been disabled.
+
+
+**--assume-yes:**
+
+*Disable confirmation prompts by assuming 'yes'*
+
+
+**--verbose:**
+
+*Enable verbose reporting from swiftly*
+
+
+**--version:**
+
+*Show the version.*
+
+
+**--help:**
+
+*Show help information.*
+
+
+
+
+## unlink
+
+Unlinks swiftly so it no longer manages the active toolchain.
+
+```
+swiftly unlink [<toolchain-selector>] [--assume-yes] [--verbose] [--version] [--help]
+```
+
+**toolchain-selector:**
+
+*Unlinks swiftly, allowing the system default toolchain to be used.*
+
+
+Unlinks swiftly until swiftly is linked again with:
+
+    $ swiftly link
+
+
+**--assume-yes:**
+
+*Disable confirmation prompts by assuming 'yes'*
+
+
+**--verbose:**
+
+*Enable verbose reporting from swiftly*
+
+
+**--version:**
+
+*Show the version.*
+
+
+**--help:**
+
+*Show help information.*
+
+
+
+

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -297,14 +297,7 @@ struct Init: SwiftlyCommand {
         }
 
         if let postInstall {
-            await ctx.print("""
-            There are some dependencies that should be installed before using this toolchain.
-            You can run the following script as the system administrator (e.g. root) to prepare
-            your system:
-
-                \(postInstall)
-
-            """)
+            await ctx.print(Messages.postInstall(postInstall))
         }
     }
 }

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -199,7 +199,8 @@ struct Install: SwiftlyCommand {
             selector = try ToolchainSelector(parsing: version)
         } else {
             if case let (_, result) = try await selectToolchain(ctx, config: &config),
-               case let .swiftVersionFile(_, sel, error) = result {
+               case let .swiftVersionFile(_, sel, error) = result
+            {
                 if let sel = sel {
                     selector = sel
                 } else if let error = error {

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -86,6 +86,7 @@ struct Install: SwiftlyCommand {
         defer {
             versionUpdateReminder()
         }
+        try await valitateLinked(ctx)
 
         var config = try await Config.load(ctx)
         let toolchainVersion = try await Self.determineToolchainVersion(ctx, version: self.version, config: &config)

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -86,7 +86,7 @@ struct Install: SwiftlyCommand {
         defer {
             versionUpdateReminder()
         }
-        try await valitateLinked(ctx)
+        try await validateLinked(ctx)
 
         var config = try await Config.load(ctx)
         let toolchainVersion = try await Self.determineToolchainVersion(ctx, version: self.version, config: &config)

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -109,37 +109,20 @@ struct Install: SwiftlyCommand {
 
         // Fish doesn't cache its path, so this instruction is not necessary.
         if pathChanged && !shell.hasSuffix("fish") {
-            await ctx.print(
-                """
-                NOTE: Swiftly has updated some elements in your path and your shell may not yet be
-                aware of the changes. You can update your shell's environment by running
-
-                hash -r
-
-                or restarting your shell.
-
-                """)
+            await ctx.print(Messages.refreshShell)
         }
 
         if let postInstallScript {
             guard let postInstallFile = self.postInstallFile else {
-                throw SwiftlyError(
-                    message: """
-
-                    There are some dependencies that should be installed before using this toolchain.
-                    You can run the following script as the system administrator (e.g. root) to prepare
-                    your system:
-
-                    \(postInstallScript)
-                    """)
+                throw SwiftlyError(message: Messages.postInstall(postInstallScript))
             }
 
             try Data(postInstallScript.utf8).write(
                 to: postInstallFile, options: .atomic
             )
         }
-    }    
-    
+    }
+
     public static func setupProxies(
         _ ctx: SwiftlyCoreContext,
         version: ToolchainVersion,

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -44,9 +44,13 @@ struct Link: SwiftlyCommand {
 
         if pathChanged {
             await ctx.print("""
-            Linked swiftly to \(toolchainVersion.name).
+            Linked swiftly to Swift \(toolchainVersion.name).
 
             \(Messages.refreshShell)
+            """)
+        } else {
+            await ctx.print("""
+            Swiftly is already linked to Swift \(toolchainVersion.name).
             """)
         }
     }

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -32,11 +32,15 @@ struct Link: SwiftlyCommand {
             config: &config
         )
 
-        let _ = try await Install.setupProxies(
+        let pathChanged = try await Install.setupProxies(
             ctx,
             version: toolchainVersion,
             verbose: self.root.verbose,
             assumeYes: self.root.assumeYes
         )
+
+        if pathChanged {
+            await ctx.print(Messages.refreshShell)
+        }
     }
 }

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -1,0 +1,42 @@
+import ArgumentParser
+import SwiftlyCore
+import Foundation
+
+struct Link: SwiftlyCommand {
+    public static let configuration = CommandConfiguration(
+        abstract: "Link swiftly so it resumes management of the active toolchain."
+    )
+
+    @Argument(help: ArgumentHelp(
+        "Links swiftly if it has been disabled.",
+        discussion: """
+
+        Links swiftly if it has been disabled.
+        """
+    ))
+    var toolchainSelector: String?
+
+    @OptionGroup var root: GlobalOptions
+
+    mutating func run() async throws {
+        try await self.run(Swiftly.createDefaultContext())
+    }
+
+    mutating func run(_ ctx: SwiftlyCoreContext) async throws {
+        try validateSwiftly(ctx)
+
+        var config = try Config.load(ctx)
+        let toolchainVersion = try await Install.determineToolchainVersion(
+            ctx,
+            version: nil,
+            config: &config
+        )
+
+        let _ = try await Install.setupProxies(
+            ctx,
+            version: toolchainVersion,
+            verbose: self.root.verbose,
+            assumeYes: self.root.assumeYes
+        )
+    }
+}

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
-import SwiftlyCore
 import Foundation
+import SwiftlyCore
 
 struct Link: SwiftlyCommand {
     public static let configuration = CommandConfiguration(

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -23,12 +23,15 @@ struct Link: SwiftlyCommand {
     }
 
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
-        try validateSwiftly(ctx)
+        let versionUpdateReminder = try await validateSwiftly(ctx)
+        defer {
+            versionUpdateReminder()
+        }
 
-        var config = try Config.load(ctx)
+        var config = try await Config.load(ctx)
         let toolchainVersion = try await Install.determineToolchainVersion(
             ctx,
-            version: nil,
+            version: config.inUse?.name,
             config: &config
         )
 
@@ -40,7 +43,11 @@ struct Link: SwiftlyCommand {
         )
 
         if pathChanged {
-            await ctx.print(Messages.refreshShell)
+            await ctx.print("""
+            Linked swiftly to \(toolchainVersion.name).
+
+            \(Messages.refreshShell)
+            """)
         }
     }
 }

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -43,11 +43,10 @@ struct List: SwiftlyCommand {
             versionUpdateReminder()
         }
 
+        var config = try await Config.load(ctx)
         let selector = try self.toolchainSelector.map { input in
             try ToolchainSelector(parsing: input)
         }
-
-        var config = try await Config.load(ctx)
 
         let toolchains = config.listInstalledToolchains(selector: selector).sorted { $0 > $1 }
         let (inUse, _) = try await selectToolchain(ctx, config: &config)

--- a/Sources/Swiftly/ListAvailable.swift
+++ b/Sources/Swiftly/ListAvailable.swift
@@ -49,11 +49,10 @@ struct ListAvailable: SwiftlyCommand {
             versionUpdateReminder()
         }
 
+        var config = try await Config.load(ctx)
         let selector = try self.toolchainSelector.map { input in
             try ToolchainSelector(parsing: input)
         }
-
-        var config = try await Config.load(ctx)
 
         let tc: [ToolchainVersion]
 

--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -62,13 +62,12 @@ struct Run: SwiftlyCommand {
         defer {
             versionUpdateReminder()
         }
+        var config = try await Config.load(ctx)
 
         // Handle the specific case where help is requested of the run subcommand
         if command == ["--help"] {
             throw CleanExit.helpRequest(self)
         }
-
-        var config = try await Config.load(ctx)
 
         let (command, selector) = try Self.extractProxyArguments(command: self.command)
 

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -47,7 +47,7 @@ public struct Swiftly: SwiftlyCommand {
             SelfUpdate.self,
             Run.self,
             Link.self,
-            Unlink.self
+            Unlink.self,
         ]
     )
 

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -10,7 +10,7 @@ import SystemPackage
 
 typealias fs = SwiftlyCore.FileSystem
 
-extension FilePath: ExpressibleByArgument {
+extension FilePath: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(argument)
     }

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -46,6 +46,8 @@ public struct Swiftly: SwiftlyCommand {
             Init.self,
             SelfUpdate.self,
             Run.self,
+            Link.self,
+            Unlink.self
         ]
     )
 

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -27,6 +27,7 @@ struct Unlink: SwiftlyCommand {
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
         try validateSwiftly(ctx)
 
+        var pathChanged = false
         if let proxyTo = try? Swiftly.currentPlatform.findSwiftlyBin(ctx) {
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(ctx)
             let swiftlyBinDirContents = (try? FileManager.default.contentsOfDirectory(atPath: swiftlyBinDir.path)) ?? [String]()
@@ -43,8 +44,13 @@ struct Unlink: SwiftlyCommand {
 
                 if proxy.fileExists() {
                     try FileManager.default.removeItem(at: proxy)
+                    pathChanged = true
                 }
             }
+        }
+
+        if pathChanged {
+            await ctx.print(Messages.refreshShell)
         }
     }
 }

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -1,0 +1,50 @@
+import ArgumentParser
+import SwiftlyCore
+import Foundation
+
+struct Unlink: SwiftlyCommand {
+    public static let configuration = CommandConfiguration(
+        abstract: "Unlinks swiftly so it no longer manages the active toolchain."
+    )
+
+    @Argument(help: ArgumentHelp(
+        "Unlinks swiftly, allowing the system default toolchain to be used.",
+        discussion: """
+
+        Unlinks swiftly until swiftly is linked again with:
+
+            $ swiftly link
+        """
+    ))
+    var toolchainSelector: String?
+
+    @OptionGroup var root: GlobalOptions
+
+    mutating func run() async throws {
+        try await self.run(Swiftly.createDefaultContext())
+    }
+
+    mutating func run(_ ctx: SwiftlyCoreContext) async throws {
+        try validateSwiftly(ctx)
+
+        if let proxyTo = try? Swiftly.currentPlatform.findSwiftlyBin(ctx) {
+            let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(ctx)
+            let swiftlyBinDirContents = (try? FileManager.default.contentsOfDirectory(atPath: swiftlyBinDir.path)) ?? [String]()
+
+            let existingProxies = swiftlyBinDirContents.filter { bin in
+                do {
+                    let linkTarget = try FileManager.default.destinationOfSymbolicLink(atPath: swiftlyBinDir.appendingPathComponent(bin).path)
+                    return linkTarget == proxyTo
+                } catch { return false }
+            }
+
+            for p in existingProxies {
+                let proxy = Swiftly.currentPlatform.swiftlyBinDir(ctx).appendingPathComponent(p)
+
+                if proxy.fileExists() {
+                    try FileManager.default.removeItem(at: proxy)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
-import SwiftlyCore
 import Foundation
+import SwiftlyCore
 
 struct Unlink: SwiftlyCommand {
     public static let configuration = CommandConfiguration(

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -55,6 +55,7 @@ struct Unlink: SwiftlyCommand {
         }
 
         if pathChanged {
+            await ctx.print(Messages.unlinkSuccess)
             await ctx.print(Messages.refreshShell)
         }
     }

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -146,15 +146,7 @@ struct Update: SwiftlyCommand {
         }
 
         if pathChanged {
-            await ctx.print("""
-            NOTE: Swiftly has updated some elements in your path and your shell may not yet be
-            aware of the changes. You can update your shell's environment by running
-
-            hash -r
-
-            or restarting your shell.
-
-            """)
+            await ctx.print(Messages.refreshShell)
         }
     }
 

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -87,7 +87,7 @@ struct Update: SwiftlyCommand {
         defer {
             versionUpdateReminder()
         }
-        try await valitateLinked(ctx)
+        try await validateLinked(ctx)
 
         var config = try await Config.load(ctx)
         guard let parameters = try await self.resolveUpdateParameters(ctx, &config) else {

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -87,9 +87,9 @@ struct Update: SwiftlyCommand {
         defer {
             versionUpdateReminder()
         }
+        try await valitateLinked(ctx)
 
         var config = try await Config.load(ctx)
-
         guard let parameters = try await self.resolveUpdateParameters(ctx, &config) else {
             if let toolchain = self.toolchain {
                 await ctx.print("No installed toolchain matched \"\(toolchain)\"")

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -67,6 +67,8 @@ struct Use: SwiftlyCommand {
 
         var config = try await Config.load(ctx)
 
+        try await valitateLinked(ctx)
+
         // This is the bare use command where we print the selected toolchain version (or the path to it)
         guard let toolchain = self.toolchain else {
             let (selectedVersion, result) = try await selectToolchain(ctx, config: &config, globalDefault: self.globalDefault)
@@ -113,6 +115,7 @@ struct Use: SwiftlyCommand {
         }
 
         try await Self.execute(ctx, toolchain, globalDefault: self.globalDefault, assumeYes: self.root.assumeYes, &config)
+
     }
 
     /// Use a toolchain. This method can modify and save the input config and also create/modify a `.swift-version` file.

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -67,7 +67,7 @@ struct Use: SwiftlyCommand {
 
         var config = try await Config.load(ctx)
 
-        try await valitateLinked(ctx)
+        try await validateLinked(ctx)
 
         // This is the bare use command where we print the selected toolchain version (or the path to it)
         guard let toolchain = self.toolchain else {

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -115,7 +115,6 @@ struct Use: SwiftlyCommand {
         }
 
         try await Self.execute(ctx, toolchain, globalDefault: self.globalDefault, assumeYes: self.root.assumeYes, &config)
-
     }
 
     /// Use a toolchain. This method can modify and save the input config and also create/modify a `.swift-version` file.

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -10,9 +10,20 @@ public enum Messages {
     """
 
     public static let unlinkSuccess = """
-    Swiftly is now unlinked and will not manage the active toolchain until the following command is run:
+    Swiftly is now unlinked and will not manage the active toolchain until the following
+    command is run:
 
         $ swiftly link
+
+
+    """
+
+    public static let currentlyUnlinked = """
+    Swiftly is currently unlinked and will not manage the active toolchain. You can run
+    the following command to link swiftly to the active toolchain:
+
+        $ swiftly link
+
 
     """
 

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -1,0 +1,22 @@
+public struct Messages {
+    public static let refreshShell = """
+    NOTE: Swiftly has updated some elements in your path and your shell may not yet be
+    aware of the changes. You can update your shell's environment by running
+
+    hash -r
+
+    or restarting your shell.
+
+    """
+
+    public static func postInstall(_ message: String) -> String {
+        """
+        There are some dependencies that should be installed before using this toolchain.
+        You can run the following script as the system administrator (e.g. root) to prepare
+        your system:
+
+            \(message)
+
+        """
+    }
+}

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -9,13 +9,20 @@ public enum Messages {
 
     """
 
-    public static func postInstall(_ message: String) -> String {
+    public static let unlinkSuccess = """
+    Swiftly is now unlinked and will not manage the active toolchain until the following command is run:
+
+        $ swiftly link
+
+    """
+
+    public static func postInstall(_ command: String) -> String {
         """
         There are some dependencies that should be installed before using this toolchain.
         You can run the following script as the system administrator (e.g. root) to prepare
         your system:
 
-            \(message)
+            \(command)
 
         """
     }

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -1,4 +1,4 @@
-public struct Messages {
+public enum Messages {
     public static let refreshShell = """
     NOTE: Swiftly has updated some elements in your path and your shell may not yet be
     aware of the changes. You can update your shell's environment by running

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -454,11 +454,6 @@ extension Platform {
             return cmdAbsolute
         }
 
-        // If we're running inside an xctest then we don't have a location for this swiftly.
-        guard let cmdAbsolute, !cmdAbsolute.string.hasSuffix("xctest") else {
-            return nil
-        }
-
         return try await fs.exists(atPath: swiftlyHomeBin) ? swiftlyHomeBin : nil
     }
 

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -454,6 +454,16 @@ extension Platform {
             return cmdAbsolute
         }
 
+        // If we're running inside an xctest then we don't have a location for this swiftly.
+        guard let cmdAbsolute,
+              !(
+                  (cmdAbsolute.string.hasSuffix("xctest") || cmdAbsolute.string.hasSuffix("swiftpm-testing-helper"))
+                      && CommandLine.arguments.contains { $0.contains("InstallTests") }
+              )
+        else {
+            return nil
+        }
+
         return try await fs.exists(atPath: swiftlyHomeBin) ? swiftlyHomeBin : nil
     }
 

--- a/Tests/SwiftlyTests/LinkTests.swift
+++ b/Tests/SwiftlyTests/LinkTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite struct LinkTests {
     /// Tests that enabling swiftly results in swiftlyBinDir being populated with symlinks.
-    @Test func testLink() async throws {
+    @Test(.testHomeMockedToolchain()) func testLink() async throws {
         try await SwiftlyTests.withTestHome {
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
             let swiftlyBinaryPath = swiftlyBinDir / "swiftly"
@@ -20,7 +20,7 @@ import Testing
             try "swiftly binary".write(to: swiftlyBinaryPath, atomically: true, encoding: .utf8)
 
             let toolchainDir = Swiftly.currentPlatform.findToolchainLocation(SwiftlyTests.ctx, toolchainVersion) / "usr" / "bin"
-            try await fs.mkdir([.parents], atPath: toolchainDir)
+            try await fs.mkdir(.parents, atPath: toolchainDir)
 
             let proxies = ["swift-build", "swift-test", "swift-run"]
             for proxy in proxies {

--- a/Tests/SwiftlyTests/LinkTests.swift
+++ b/Tests/SwiftlyTests/LinkTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+@testable import Swiftly
+@testable import SwiftlyCore
+import Testing
+
+@Suite struct LinkTests {
+    /// Tests that enabling swiftly results in swiftlyBinDir being populated with symlinks.
+    @Test func testLink() async throws {
+        try await SwiftlyTests.withTestHome {
+            let fm = FileManager.default
+            let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
+            let swiftlyBinaryPath = swiftlyBinDir.appendingPathComponent("swiftly")
+            let swiftVersionFilename = SwiftlyTests.ctx.currentDirectory.appendingPathComponent(".swift-version")
+
+            // Configure a mock toolchain
+            let versionString = "6.0.3"
+            let toolchainVersion = try ToolchainVersion(parsing: versionString)
+            try versionString.write(to: swiftVersionFilename, atomically: true, encoding: .utf8)
+
+            // And start creating a mock folder structure for that toolchain.
+            try "swiftly binary".write(to: swiftlyBinaryPath, atomically: true, encoding: .utf8)
+
+            let toolchainDir = Swiftly.currentPlatform.findToolchainLocation(SwiftlyTests.ctx, toolchainVersion)
+                .appendingPathComponent("usr")
+                .appendingPathComponent("bin")
+            try fm.createDirectory(at: toolchainDir, withIntermediateDirectories: true)
+
+            let proxies = ["swift-build", "swift-test", "swift-run"]
+            for proxy in proxies {
+                let proxyPath = toolchainDir.appendingPathComponent(proxy)
+                try fm.createSymbolicLink(at: proxyPath, withDestinationURL: swiftlyBinaryPath)
+            }
+
+            _ = try await SwiftlyTests.runWithMockedIO(Link.self, ["link"])
+
+            let enabledSwiftlyBinDirContents = try fm.contentsOfDirectory(atPath: swiftlyBinDir.path).sorted()
+            let expectedProxies = (["swiftly"] + proxies).sorted()
+            #expect(enabledSwiftlyBinDirContents == expectedProxies)
+        }
+    }
+}

--- a/Tests/SwiftlyTests/UnlinkTests.swift
+++ b/Tests/SwiftlyTests/UnlinkTests.swift
@@ -7,20 +7,19 @@ import Testing
     /// Tests that disabling swiftly results in swiftlyBinDir with no symlinks to toolchain binaries in it.
     @Test func testUnlink() async throws {
         try await SwiftlyTests.withTestHome {
-            let fm = FileManager.default
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
-            let swiftlyBinaryPath = swiftlyBinDir.appendingPathComponent("swiftly")
+            let swiftlyBinaryPath = swiftlyBinDir / "swiftly"
             try "mockBinary".write(to: swiftlyBinaryPath, atomically: true, encoding: .utf8)
 
             let proxies = ["swift-build", "swift-test", "swift-run"]
             for proxy in proxies {
-                let proxyPath = swiftlyBinDir.appendingPathComponent(proxy)
-                try fm.createSymbolicLink(at: proxyPath, withDestinationURL: swiftlyBinaryPath)
+                let proxyPath = swiftlyBinDir / proxy
+                try await fs.symlink(atPath: proxyPath, linkPath: swiftlyBinaryPath)
             }
 
             _ = try await SwiftlyTests.runWithMockedIO(Unlink.self, ["unlink"])
 
-            let disabledSwiftlyBinDirContents = try fm.contentsOfDirectory(atPath: swiftlyBinDir.path)
+            let disabledSwiftlyBinDirContents = try await fs.ls(atPath: swiftlyBinDir)
             #expect(disabledSwiftlyBinDirContents == ["swiftly"])
         }
     }

--- a/Tests/SwiftlyTests/UnlinkTests.swift
+++ b/Tests/SwiftlyTests/UnlinkTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite struct UnlinkTests {
     /// Tests that disabling swiftly results in swiftlyBinDir with no symlinks to toolchain binaries in it.
     @Test func testUnlink() async throws {
-    try await SwiftlyTests.withTestHome {
+        try await SwiftlyTests.withTestHome {
             let fm = FileManager.default
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
             let swiftlyBinaryPath = swiftlyBinDir.appendingPathComponent("swiftly")

--- a/Tests/SwiftlyTests/UnlinkTests.swift
+++ b/Tests/SwiftlyTests/UnlinkTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import Swiftly
+@testable import SwiftlyCore
+import Testing
+
+@Suite struct UnlinkTests {
+    /// Tests that disabling swiftly results in swiftlyBinDir with no symlinks to toolchain binaries in it.
+    @Test func testUnlink() async throws {
+    try await SwiftlyTests.withTestHome {
+            let fm = FileManager.default
+            let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
+            let swiftlyBinaryPath = swiftlyBinDir.appendingPathComponent("swiftly")
+            try "mockBinary".write(to: swiftlyBinaryPath, atomically: true, encoding: .utf8)
+
+            let proxies = ["swift-build", "swift-test", "swift-run"]
+            for proxy in proxies {
+                let proxyPath = swiftlyBinDir.appendingPathComponent(proxy)
+                try fm.createSymbolicLink(at: proxyPath, withDestinationURL: swiftlyBinaryPath)
+            }
+
+            _ = try await SwiftlyTests.runWithMockedIO(Unlink.self, ["unlink"])
+
+            let disabledSwiftlyBinDirContents = try fm.contentsOfDirectory(atPath: swiftlyBinDir.path)
+            #expect(disabledSwiftlyBinDirContents == ["swiftly"])
+        }
+    }
+}

--- a/Tests/SwiftlyTests/UnlinkTests.swift
+++ b/Tests/SwiftlyTests/UnlinkTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite struct UnlinkTests {
     /// Tests that disabling swiftly results in swiftlyBinDir with no symlinks to toolchain binaries in it.
-    @Test func testUnlink() async throws {
+    @Test(.testHomeMockedToolchain()) func testUnlink() async throws {
         try await SwiftlyTests.withTestHome {
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)
             let swiftlyBinaryPath = swiftlyBinDir / "swiftly"


### PR DESCRIPTION
Adds two new commands, `swiftly unlink` and `swiftly link`, which will disable and reenable swiftly's management of the active toolchain.

The `unlink` command removes the symlinks to toolchain binaries in the swiftly bin directory that is in the user's path. This allows the rest of the `$PATH` to be searched for available toolchain installations, falling back to the system default. On macOS with Xcode installed this has the effect of falling back to the toolchain in the user's installed Xcode.

The `link` command reinstates the symlinks to the `inUse` toolchain, which allows swiftly to resume management of the active toolchain.