### PR TITLE
Create a special xcode selector that will delegates to xcrun for macOS

### DIFF
--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -207,9 +207,15 @@ public struct MacOS: Platform {
         return "/bin/zsh"
     }
 
-    public func findToolchainLocation(_ ctx: SwiftlyCoreContext, _ toolchain: ToolchainVersion) -> URL
-    {
-        self.swiftlyToolchainsDir(ctx).appendingPathComponent("\(toolchain.identifier).xctoolchain")
+    public func findToolchainLocation(_ ctx: SwiftlyCoreContext, _ toolchain: ToolchainVersion) async throws -> URL {
+        if toolchain == .xcodeVersion {
+            // Print the toolchain location with the help of xcrun
+            if let xcrunLocation = try? await self.runProgramOutput("/usr/bin/xcrun", "-f", "swift") {
+                return URL(filePath: xcrunLocation.replacingOccurrences(of: "\n", with: "")).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            }
+        }
+
+        return self.swiftlyToolchainsDir(ctx).appendingPathComponent("\(toolchain.identifier).xctoolchain")
     }
 
     public static let currentPlatform: any Platform = MacOS()

--- a/Sources/Swiftly/Config.swift
+++ b/Sources/Swiftly/Config.swift
@@ -52,7 +52,7 @@ public struct Config: Codable, Equatable {
 
     public func listInstalledToolchains(selector: ToolchainSelector?) -> [ToolchainVersion] {
         guard let selector else {
-            return Array(self.installedToolchains)
+            return Array(self.installedToolchains) + [.xcodeVersion]
         }
 
         if case .latest = selector {
@@ -63,7 +63,7 @@ public struct Config: Codable, Equatable {
             return ts
         }
 
-        return self.installedToolchains.filter { toolchain in
+        return (self.installedToolchains + [.xcodeVersion]).filter { toolchain in
             selector.matches(toolchain: toolchain)
         }
     }

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -216,6 +216,8 @@ struct Install: SwiftlyCommand {
             case .main:
                 category = "development"
             }
+        case .xcode:
+            fatalError("unreachable: xcode toolchain cannot be installed with swiftly")
         }
 
         let animation = PercentProgressAnimation(
@@ -282,7 +284,7 @@ struct Install: SwiftlyCommand {
             let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(ctx)
             let swiftlyBinDirContents =
                 (try? FileManager.default.contentsOfDirectory(atPath: swiftlyBinDir.path)) ?? [String]()
-            let toolchainBinDir = Swiftly.currentPlatform.findToolchainBinDir(ctx, version)
+            let toolchainBinDir = try await Swiftly.currentPlatform.findToolchainBinDir(ctx, version)
             let toolchainBinDirContents = try FileManager.default.contentsOfDirectory(
                 atPath: toolchainBinDir.path)
 
@@ -429,6 +431,8 @@ struct Install: SwiftlyCommand {
             }
 
             return .snapshot(firstSnapshot)
+        case .xcode:
+            throw SwiftlyError(message: "xcode toolchains are not available from swift.org")
         }
     }
 }

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -97,6 +97,9 @@ struct List: SwiftlyCommand {
             for toolchain in toolchains where toolchain.isSnapshot() {
                 await printToolchain(toolchain)
             }
+
+            await ctx.print("")
+            await printToolchain(ToolchainVersion.xcode)
         }
     }
 }

--- a/Sources/Swiftly/Uninstall.swift
+++ b/Sources/Swiftly/Uninstall.swift
@@ -51,7 +51,7 @@ struct Uninstall: SwiftlyCommand {
         try validateSwiftly(ctx)
         let startingConfig = try Config.load(ctx)
 
-        let toolchains: [ToolchainVersion]
+        var toolchains: [ToolchainVersion]
         if self.toolchain == "all" {
             // Sort the uninstalled toolchains such that the in-use toolchain will be uninstalled last.
             // This avoids printing any unnecessary output from using new toolchains while the uninstall is in progress.
@@ -67,6 +67,8 @@ struct Uninstall: SwiftlyCommand {
             }
             toolchains = installedToolchains
         }
+
+        toolchains.removeAll(where: { $0 == .xcodeVersion })
 
         guard !toolchains.isEmpty else {
             await ctx.print("No toolchains matched \"\(self.toolchain)\"")
@@ -101,6 +103,9 @@ struct Uninstall: SwiftlyCommand {
                 case let .snapshot(s):
                     // If a snapshot was previously in use, switch to the latest snapshot associated with that branch.
                     selector = .snapshot(branch: s.branch, date: nil)
+                case .xcode:
+                    // Xcode will not be in the list of installed toolchains, so this is only here for completeness
+                    selector = .xcode
                 }
 
                 if let toUse = config.listInstalledToolchains(selector: selector)

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -195,6 +195,8 @@ struct Update: SwiftlyCommand {
             default:
                 fatalError("unreachable")
             }
+        case let .xcode:
+            throw SwiftlyError(message: "xcode cannot be updated from swiftly")
         }
     }
 

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -78,7 +78,7 @@ struct Use: SwiftlyCommand {
 
             if self.printLocation {
                 // Print the toolchain location and exit
-                await ctx.print("\(Swiftly.currentPlatform.findToolchainLocation(ctx, selectedVersion).path)")
+                await ctx.print("\(try await Swiftly.currentPlatform.findToolchainLocation(ctx, selectedVersion).path)")
                 return
             }
 

--- a/Tests/SwiftlyTests/UseTests.swift
+++ b/Tests/SwiftlyTests/UseTests.swift
@@ -202,7 +202,9 @@ import Testing
 
                 output = try await SwiftlyTests.runWithMockedIO(Use.self, ["use", "-g", "--print-location"])
 
-                #expect(output.contains(where: { $0.contains(Swiftly.currentPlatform.findToolchainLocation(SwiftlyTests.ctx, toolchain).path) }))
+                let location = try await Swiftly.currentPlatform.findToolchainLocation(SwiftlyTests.ctx, toolchain).path
+
+                #expect(output.contains(where: { $0.contains(location) }))
             }
         }
     }


### PR DESCRIPTION
Add the feature of a special selector "xcode" that can be used like the other swiftly
selectors for some operations, such as `swiftly use`, and `swiftly list`, but has no
real effect on other operations.

With this feature, you can `swiftly use xcode` and then when you run the proxies for
items like swift, clang, and other common toolchain binaries they will be run as the
equivalent `xcrun` command.

```
swift --version  => xcrun swift --version
clang foo.c => xcrun clang foo.c
```

When xcode is selected then `swiftly run` will run with the currently selected xcode
toolchain (or command-line tools) reported by `xcrun -f` as the toolchain on the path.

When you run `swiftly list` there is a special entry for "xcode" that is decorated in a
similar way to indicate whether it is the (global) default, and/or in-use toolchain as a
result of the selection mechanism.

TODO:
* Document the new selector in all of the usual places
* Condition the selector and everything that is related to it on the macOS platform so that Linux users do not see it
* Write specific test cases for this version, selector, and commands that take versions or selectors