### PR TITLE
Make the toolchains directory location configurable

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -28,7 +28,7 @@ public struct Linux: Platform {
     }
 
     public func swiftlyBinDir(_ ctx: SwiftlyCoreContext) -> URL {
-        ctx.mockedHomeDir.map { $0.appendingPathComponent(".local/share/swiftly/bin", isDirectory: true) }
+        ctx.mockedHomeDir.map { $0.appendingPathComponent("bin", isDirectory: true) }
             ?? ProcessInfo.processInfo.environment["SWIFTLY_BIN_DIR"].map { URL(fileURLWithPath: $0) }
             ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/swiftly/bin", isDirectory: true)

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -35,7 +35,7 @@ public struct Linux: Platform {
     }
 
     public func swiftlyToolchainsDir(_ ctx: SwiftlyCoreContext) -> URL {
-        ctx.mockedHomeDir.map { $0.appendingPathComponent(".local/share/swiftly/toolchains", isDirectory: true) }
+        ctx.mockedHomeDir.map { $0.appendingPathComponent("toolchains", isDirectory: true) }
             ?? ProcessInfo.processInfo.environment["SWIFTLY_TOOLCHAINS_DIR"].map { URL(fileURLWithPath: $0) }
             ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/share/swiftly/toolchains")
     }

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -28,14 +28,16 @@ public struct Linux: Platform {
     }
 
     public func swiftlyBinDir(_ ctx: SwiftlyCoreContext) -> URL {
-        ctx.mockedHomeDir.map { $0.appendingPathComponent("bin", isDirectory: true) }
+        ctx.mockedHomeDir.map { $0.appendingPathComponent(".local/share/swiftly/bin", isDirectory: true) }
             ?? ProcessInfo.processInfo.environment["SWIFTLY_BIN_DIR"].map { URL(fileURLWithPath: $0) }
             ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/swiftly/bin", isDirectory: true)
     }
 
     public func swiftlyToolchainsDir(_ ctx: SwiftlyCoreContext) -> URL {
-        self.swiftlyHomeDir(ctx).appendingPathComponent("toolchains", isDirectory: true)
+        ctx.mockedHomeDir.map { $0.appendingPathComponent(".local/share/swiftly/toolchains", isDirectory: true) }
+            ?? ProcessInfo.processInfo.environment["SWIFTLY_TOOLCHAINS_DIR"].map { URL(fileURLWithPath: $0) }
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/share/swiftly/toolchains")
     }
 
     public var toolchainFileExtension: String {

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -171,7 +171,7 @@ extension Platform {
         guard tcPath.fileExists() else {
             throw SwiftlyError(
                 message:
-                "Toolchain \(toolchain) could not be located. You can try `swiftly uninstall \(toolchain)` to uninstall it and then `swiftly install \(toolchain)` to install it again."
+                "Toolchain \(toolchain) could not be located in \(tcPath). You can try `swiftly uninstall \(toolchain)` to uninstall it and then `swiftly install \(toolchain)` to install it again."
             )
         }
 


### PR DESCRIPTION
Using a new environment variable SWIFTLY_TOOLCHAINS_DIR that follows a similar pattern as SWIFTLY_HOME_DIR and SWIFTLY_BIN_DIR make it possible for the user to configure the toolchain location on init in the same way.

On macOS, this level of configuration requires a different approach to extracting the toolchain whenever the installation location is anything other than the default. Use the pkgutil utility of macOS to extract the toolchain in the location specified by the user. Installing the toolchains outside of the installer in a custom location means that Xcode may not be able to pick them up easily. Make a note of that in the init screen so that users are aware.

When using the init `--no-modify-profile` flag the init was skiping steps like installing the latest toolchain, and emitting the notes about updating the current shell environment. Separate this logic so that the user can have these steps performed with the flag.

This can help with #323 if you use `pkgutil --extract` and `pkgutil --check-signature` to extract swiftly, and then swiftly will install toolchains using a similar mechanism, provided that you customize the `SWIFTLY_TOOLCHAINS_DIR` to something other than the default.