### PR TITLE
Model additional system commands

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftlyCore
 import SystemPackage
 
+typealias sys = SwiftlyCore.SystemCommand
 typealias fs = SwiftlyCore.FileSystem
 
 /// `Platform` implementation for Linux systems.
@@ -605,15 +606,8 @@ public struct Linux: Platform {
 
     public func getShell() async throws -> String {
         let userName = ProcessInfo.processInfo.userName
-        let prefix = "\(userName):"
-        if let passwds = try await runProgramOutput("getent", "passwd") {
-            for line in passwds.components(separatedBy: "\n") {
-                if line.hasPrefix(prefix) {
-                    if case let comps = line.components(separatedBy: ":"), comps.count > 1 {
-                        return comps[comps.count - 1]
-                    }
-                }
-            }
+        if let entry = try await sys.getent(database: "passwd", keys: userName).entries(self).first {
+            if let shell = entry.last { return shell }
         }
 
         // Fall back on bash on Linux and other Unixes

--- a/Sources/SwiftlyCore/Commands.swift
+++ b/Sources/SwiftlyCore/Commands.swift
@@ -279,3 +279,207 @@ extension SystemCommand.GetentCommand: Output {
         return entries
     }
 }
+
+extension SystemCommand {
+    public static func git(executable: Executable = GitCommand.defaultExecutable, workingDir: FilePath? = nil) -> GitCommand {
+        GitCommand(executable: executable, workingDir: workingDir)
+    }
+
+    public struct GitCommand {
+        public static var defaultExecutable: Executable { .name("git") }
+
+        var executable: Executable
+
+        var workingDir: FilePath?
+
+        internal init(executable: Executable, workingDir: FilePath?) {
+            self.executable = executable
+            self.workingDir = workingDir
+        }
+
+        func config() -> Configuration {
+            var args: [String] = []
+
+            if let workingDir {
+                args += ["-C", "\(workingDir)"]
+            }
+
+            return Configuration(
+                executable: self.executable,
+                arguments: Arguments(args),
+                environment: .inherit
+            )
+        }
+
+        public func _init() -> InitCommand {
+            InitCommand(self)
+        }
+
+        public struct InitCommand {
+            var git: GitCommand
+
+            internal init(_ git: GitCommand) {
+                self.git = git
+            }
+
+            public func config() -> Configuration {
+                var c = self.git.config()
+
+                var args = c.arguments.storage.map(\.description)
+
+                args += ["init"]
+
+                c.arguments = .init(args)
+
+                return c
+            }
+        }
+
+        public func commit(_ options: CommitCommand.Option...) -> CommitCommand {
+            self.commit(options: options)
+        }
+
+        public func commit(options: [CommitCommand.Option]) -> CommitCommand {
+            CommitCommand(self, options: options)
+        }
+
+        public struct CommitCommand {
+            var git: GitCommand
+
+            var options: [Option]
+
+            internal init(_ git: GitCommand, options: [Option]) {
+                self.git = git
+                self.options = options
+            }
+
+            public enum Option {
+                case allowEmpty
+                case allowEmptyMessage
+                case message(String)
+
+                public func args() -> [String] {
+                    switch self {
+                    case .allowEmpty:
+                        ["--allow-empty"]
+                    case .allowEmptyMessage:
+                        ["--allow-empty-message"]
+                    case let .message(message):
+                        ["-m", message]
+                    }
+                }
+            }
+
+            public func config() -> Configuration {
+                var c = self.git.config()
+
+                var args = c.arguments.storage.map(\.description)
+
+                args += ["commit"]
+                for option in self.options {
+                    args += option.args()
+                }
+
+                c.arguments = .init(args)
+
+                return c
+            }
+        }
+
+        public func log(_ options: LogCommand.Option...) -> LogCommand {
+            LogCommand(self, options)
+        }
+
+        public struct LogCommand {
+            var git: GitCommand
+            var options: [Option]
+
+            internal init(_ git: GitCommand, _ options: [Option]) {
+                self.git = git
+                self.options = options
+            }
+
+            public enum Option {
+                case maxCount(Int)
+                case pretty(String)
+
+                func args() -> [String] {
+                    switch self {
+                    case let .maxCount(num):
+                        return ["--max-count=\(num)"]
+                    case let .pretty(format):
+                        return ["--pretty=\(format)"]
+                    }
+                }
+            }
+
+            public func config() -> Configuration {
+                var c = self.git.config()
+
+                var args = c.arguments.storage.map(\.description)
+
+                args += ["log"]
+
+                for opt in self.options {
+                    args += opt.args()
+                }
+
+                c.arguments = .init(args)
+
+                return c
+            }
+        }
+
+        public func diffIndex(_ options: DiffIndexCommand.Option..., treeIsh: String?) -> DiffIndexCommand {
+            DiffIndexCommand(self, options, treeIsh: treeIsh)
+        }
+
+        public struct DiffIndexCommand {
+            var git: GitCommand
+            var options: [Option]
+            var treeIsh: String?
+
+            internal init(_ git: GitCommand, _ options: [Option], treeIsh: String?) {
+                self.git = git
+                self.options = options
+                self.treeIsh = treeIsh
+            }
+
+            public enum Option {
+                case quiet
+
+                func args() -> [String] {
+                    switch self {
+                    case .quiet:
+                        return ["--quiet"]
+                    }
+                }
+            }
+
+            public func config() -> Configuration {
+                var c = self.git.config()
+
+                var args = c.arguments.storage.map(\.description)
+
+                args += ["diff-index"]
+
+                for opt in self.options {
+                    args += opt.args()
+                }
+
+                if let treeIsh = self.treeIsh {
+                    args += [treeIsh]
+                }
+
+                c.arguments = .init(args)
+
+                return c
+            }
+        }
+    }
+}
+
+extension SystemCommand.GitCommand.LogCommand: Output {}
+extension SystemCommand.GitCommand.DiffIndexCommand: Runnable {}
+extension SystemCommand.GitCommand.InitCommand: Runnable {}
+extension SystemCommand.GitCommand.CommitCommand: Runnable {}

--- a/Sources/SwiftlyCore/Commands.swift
+++ b/Sources/SwiftlyCore/Commands.swift
@@ -30,7 +30,7 @@ extension SystemCommand {
             var args: [String] = []
 
             if let datasource = self.datasource {
-                args += [datasource]
+                args.append(datasource)
             }
 
             return Configuration(
@@ -65,8 +65,10 @@ extension SystemCommand {
                 var args = c.arguments.storage.map(\.description) + ["-read"]
 
                 if let path = self.path {
-                    args += [path.string] + self.keys
+                    args.append(path.string)
                 }
+
+                args.append(contentsOf: self.keys)
 
                 c.arguments = .init(args)
 
@@ -116,7 +118,7 @@ extension SystemCommand {
         func config() -> Configuration {
             var args: [String] = []
 
-            args += self.inputFiles.map(\.string)
+            args.append(contentsOf: self.inputFiles.map(\.string))
 
             return Configuration(
                 executable: self.executable,
@@ -205,11 +207,11 @@ extension SystemCommand {
             var args: [String] = []
 
             for option in self.options {
-                args += option.args()
+                args.append(contentsOf: option.args())
             }
 
-            args += ["--root", "\(self.root)"]
-            args += ["\(self.packageOutputPath)"]
+            args.append(contentsOf: ["--root", "\(self.root)"])
+            args.append("\(self.packageOutputPath)")
 
             return Configuration(
                 executable: self.executable,
@@ -255,8 +257,8 @@ extension SystemCommand {
         public func config() -> Configuration {
             var args: [String] = []
 
-            args += [self.database]
-            args += self.keys
+            args.append(self.database)
+            args.append(contentsOf: self.keys)
 
             return Configuration(
                 executable: self.executable,
@@ -301,7 +303,7 @@ extension SystemCommand {
             var args: [String] = []
 
             if let workingDir {
-                args += ["-C", "\(workingDir)"]
+                args.append(contentsOf: ["-C", "\(workingDir)"])
             }
 
             return Configuration(
@@ -327,7 +329,7 @@ extension SystemCommand {
 
                 var args = c.arguments.storage.map(\.description)
 
-                args += ["init"]
+                args.append("init")
 
                 c.arguments = .init(args)
 
@@ -375,9 +377,9 @@ extension SystemCommand {
 
                 var args = c.arguments.storage.map(\.description)
 
-                args += ["commit"]
+                args.append("commit")
                 for option in self.options {
-                    args += option.args()
+                    args.append(contentsOf: option.args())
                 }
 
                 c.arguments = .init(args)
@@ -418,10 +420,10 @@ extension SystemCommand {
 
                 var args = c.arguments.storage.map(\.description)
 
-                args += ["log"]
+                args.append("log")
 
                 for opt in self.options {
-                    args += opt.args()
+                    args.append(contentsOf: opt.args())
                 }
 
                 c.arguments = .init(args)
@@ -461,14 +463,14 @@ extension SystemCommand {
 
                 var args = c.arguments.storage.map(\.description)
 
-                args += ["diff-index"]
+                args.append("diff-index")
 
                 for opt in self.options {
-                    args += opt.args()
+                    args.append(contentsOf: opt.args())
                 }
 
                 if let treeIsh = self.treeIsh {
-                    args += [treeIsh]
+                    args.append(treeIsh)
                 }
 
                 c.arguments = .init(args)

--- a/Sources/SwiftlyCore/ModeledCommandLine.swift
+++ b/Sources/SwiftlyCore/ModeledCommandLine.swift
@@ -136,11 +136,7 @@ extension Executable: CustomStringConvertible {
 extension Arguments: CustomStringConvertible {
     public var description: String {
         let normalized: [String] = self.storage.map(\.description).map {
-            if $0.contains(" ") {
-                return "\"\($0)\""
-            } else {
-                return String($0)
-            }
+            $0.contains(" ") ? "\"\($0)\"" : String($0)
         }
 
         return normalized.joined(separator: " ")

--- a/Sources/SwiftlyCore/ModeledCommandLine.swift
+++ b/Sources/SwiftlyCore/ModeledCommandLine.swift
@@ -121,6 +121,38 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
     }
 }
 
+// Provide string representations of Configuration
+extension Executable: CustomStringConvertible {
+    public var description: String {
+        switch self.storage {
+        case let .executable(name):
+            name
+        case let .path(path):
+            path.string
+        }
+    }
+}
+
+extension Arguments: CustomStringConvertible {
+    public var description: String {
+        let normalized: [String] = self.storage.map(\.description).map {
+            if $0.contains(" ") {
+                return "\"\($0)\""
+            } else {
+                return String($0)
+            }
+        }
+
+        return normalized.joined(separator: " ")
+    }
+}
+
+extension Configuration: CustomStringConvertible {
+    public var description: String {
+        "\(self.executable) \(self.arguments)"
+    }
+}
+
 public protocol Runnable {
     func config() -> Configuration
 }

--- a/Tests/SwiftlyTests/CommandLineTests.swift
+++ b/Tests/SwiftlyTests/CommandLineTests.swift
@@ -46,5 +46,19 @@ public struct CommandLineTests {
 
         config = sys.pkgbuild(.version("1234"), root: "somepath", packageOutputPath: "output").config()
         #expect(String(describing: config) == "pkgbuild --version 1234 --root somepath output")
+
+        config = sys.pkgbuild(.installLocation("/usr/local"), .version("1.0.0"), .identifier("org.foo.bar"), .sign("mycert"), root: "someroot", packageOutputPath: "my.pkg").config()
+        #expect(String(describing: config) == "pkgbuild --install-location /usr/local --version 1.0.0 --identifier org.foo.bar --sign mycert --root someroot my.pkg")
+
+        config = sys.pkgbuild(.installLocation("/usr/local"), .version("1.0.0"), .identifier("org.foo.bar"), root: "someroot", packageOutputPath: "my.pkg").config()
+        #expect(String(describing: config) == "pkgbuild --install-location /usr/local --version 1.0.0 --identifier org.foo.bar --root someroot my.pkg")
+    }
+
+    @Test func testGetent() {
+        var config = sys.getent(database: "passwd", keys: "swiftly").config()
+        #expect(String(describing: config) == "getent passwd swiftly")
+
+        config = sys.getent(database: "foo", keys: "abc", "def").config()
+        #expect(String(describing: config) == "getent foo abc def")
     }
 }

--- a/Tests/SwiftlyTests/CommandLineTests.swift
+++ b/Tests/SwiftlyTests/CommandLineTests.swift
@@ -39,4 +39,12 @@ public struct CommandLineTests {
         #expect(config.executable == .name("lipo"))
         #expect(config.arguments.storage.map(\.description) == ["swiftly", "-create", "-output", "swiftly-universal-with-one-arch"])
     }
+
+    @Test func testPkgbuild() {
+        var config = sys.pkgbuild(root: "mypath", packageOutputPath: "outputDir").config()
+        #expect(String(describing: config) == "pkgbuild --root mypath outputDir")
+
+        config = sys.pkgbuild(.version("1234"), root: "somepath", packageOutputPath: "output").config()
+        #expect(String(describing: config) == "pkgbuild --version 1234 --root somepath output")
+    }
 }

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -940,22 +940,14 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
 
         let pkg = tmp / "swiftly.pkg"
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = [
-            "pkgbuild",
-            "--root",
-            "\(swiftlyDir)",
-            "--install-location",
-            ".swiftly",
-            "--version",
-            "\(self.latestSwiftlyVersion)",
-            "--identifier",
-            "org.swift.swiftly",
-            "\(pkg)",
-        ]
-        try task.run()
-        task.waitUntilExit()
+        try await sys.pkgbuild(
+            .installLocation("swiftly"),
+            .version("\(self.latestSwiftlyVersion)"),
+            .identifier("org.swift.swiftly"),
+            root: swiftlyDir,
+            packageOutputPath: pkg
+        )
+        .run(Swiftly.currentPlatform)
 
         let data = try Data(contentsOf: pkg)
         try await fs.remove(atPath: tmp)
@@ -993,24 +985,16 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
         let data = try encoder.encode(pkgInfo)
         try data.write(to: toolchainDir.appending("Info.plist"))
 
-        let pkg = tmp.appending("toolchain.pkg")
+        let pkg = tmp / "toolchain.pkg"
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = [
-            "pkgbuild",
-            "--root",
-            "\(toolchainDir)",
-            "--install-location",
-            "Library/Developer/Toolchains/\(toolchain.identifier).xctoolchain",
-            "--version",
-            "\(toolchain.name)",
-            "--identifier",
-            pkgInfo.CFBundleIdentifier,
-            "\(pkg)",
-        ]
-        try task.run()
-        task.waitUntilExit()
+        try await sys.pkgbuild(
+            .installLocation(FilePath("Library/Developer/Toolchains/\(toolchain.identifier).xctoolchain")),
+            .version("\(toolchain.name)"),
+            .identifier(pkgInfo.CFBundleIdentifier),
+            root: toolchainDir,
+            packageOutputPath: pkg
+        )
+        .run(Swiftly.currentPlatform)
 
         let pkgData = try Data(contentsOf: pkg)
         try await fs.remove(atPath: tmp)

--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -236,17 +236,17 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         return swift
     }
 
-    func checkGitRepoStatus(_ git: String) async throws {
+    func checkGitRepoStatus(_: String) async throws {
         guard !self.skip else {
             return
         }
 
-        guard let gitTags = try await runProgramOutput(git, "log", "-n1", "--pretty=format:%d"), gitTags.contains("tag: \(self.version)") else {
+        guard let gitTags = try await sys.git().log(.maxCount(1), .pretty("format:%d")).output(currentPlatform), gitTags.contains("tag: \(self.version)") else {
             throw Error(message: "Git repo is not yet tagged for release \(self.version). Please tag this commit with that version and push it to GitHub.")
         }
 
         do {
-            try runProgram(git, "diff-index", "--quiet", "HEAD")
+            try await sys.git().diffIndex(.quiet, treeIsh: "HEAD").run(currentPlatform)
         } catch {
             throw Error(message: "Git repo has local changes. First commit these changes, tag the commit with release \(self.version) and push the tag to GitHub.")
         }


### PR DESCRIPTION
Model the pkgbuild command with the usual structure used for other commands.

Provide a custom string convertible implementation for configuration so that the
configuration can be easily converted into a string for logging and comparison
purposes.

Create a runEcho() implementation for the build swiftly release script so that
commands can output their command-line to the log for reproducibility.

Add a model for the Linux getent command. Provide a convenience entries() method
that provides a table of the entries for better ease of use.

Model a small subset of the git command for use in the build swiftly release script and
testing of it.