### PR TITLE
Smoke test swiftly on nightly snapshot toolchains

### DIFF
--- a/.github/workflows/nightly_snapshot_check.yml
+++ b/.github/workflows/nightly_snapshot_check.yml
@@ -1,9 +1,6 @@
 on:
   schedule:
     - cron: '30 3 * * *'
-  # TODO REMOVE THESE
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 env:
   SWIFTLY_BOOTSTRAP_VERSION: 1.0.0

--- a/.github/workflows/nightly_snapshot_check.yml
+++ b/.github/workflows/nightly_snapshot_check.yml
@@ -1,13 +1,16 @@
 on:
   schedule:
     - cron: '30 3 * * *'
+  # TODO REMOVE THESE
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 env:
   SWIFTLY_BOOTSTRAP_VERSION: 1.0.0
 
 jobs:
   tests-selfhosted:
-    name: Test (Self Hosted) / ${{ matrix.container }}
+    name: Test (Smoke Test - Nightly Swift Toolchain) / ${{ matrix.container }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -19,9 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Prepare the action
-        run: ./scripts/prep-gh-action.sh --install-swiftly
-      - name: Install main-snapshot toolchain
-        run: swiftly install main-snapshot
+        run: ./scripts/prep-gh-action.sh --install-swiftly --swift-main-snapshot
       - name: Build and Test
         # UBI 9 and Ubuntu 20.04 - See https://github.com/swiftlang/swift/issues/80908
         # UBI 9 - See https://github.com/swiftlang/swift/issues/80909

--- a/.github/workflows/nightly_snapshot_check.yml
+++ b/.github/workflows/nightly_snapshot_check.yml
@@ -1,3 +1,5 @@
+name: Smoke Test - Nightly Swift Toolchain
+
 on:
   schedule:
     - cron: '30 3 * * *'

--- a/.github/workflows/nightly_snapshot_check.yml
+++ b/.github/workflows/nightly_snapshot_check.yml
@@ -1,0 +1,31 @@
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  # TODO REMOVE THESE
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+env:
+  SWIFTLY_BOOTSTRAP_VERSION: 1.0.0
+
+jobs:
+  tests-selfhosted:
+    name: Test (Self Hosted) / ${{ matrix.container }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "redhat/ubi9", "debian:12", "fedora:39"]
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Prepare the action
+        run: ./scripts/prep-gh-action.sh --install-swiftly
+      - name: Install main-snapshot toolchain
+        run: swiftly install main-snapshot
+      - name: Build and Test
+        # UBI 9 and Ubuntu 20.04 - See https://github.com/swiftlang/swift/issues/80908
+        # UBI 9 - See https://github.com/swiftlang/swift/issues/80909
+        run: bash -c 'if [[ "${{ matrix.container }}" == "redhat/ubi9" ]]; then swiftly run +main-snapshot swift build --build-tests; elif [[ "${{ matrix.container }}" == "ubuntu:20.04" ]]; then swiftly run +main-snapshot swift build --build-tests; else swiftly run +main-snapshot swift test; fi'

--- a/scripts/prep-gh-action.sh
+++ b/scripts/prep-gh-action.sh
@@ -62,7 +62,7 @@ if [ "$installSwiftly" == true ]; then
     fi
 
     echo "Displaying swift version"
-    swift "${selector[@]} --version
+    swiftly run "${runSelector[@]}" swift --version
 
     CC=clang swiftly run "${runSelector[@]}" "$(dirname "$0")/install-libarchive.sh"
 else

--- a/scripts/prep-gh-action.sh
+++ b/scripts/prep-gh-action.sh
@@ -44,7 +44,7 @@ if [ "$installSwiftly" == true ]; then
         echo "Installing latest main-snapshot toolchain"
         selector=("main-snapshot")
         runSelector=("+main-snapshot")
-    if [ -f .swift-version ]; then
+    elif [ -f .swift-version ]; then
         echo "Installing selected swift toolchain from .swift-version file"
         selector=()
         runSelector=()


### PR DESCRIPTION
From time-to-time swiftly will need to update the Swift toolchain. In preparation
for the update, it will be good to be able to track how well it is working with those
toolchains on a regular basis.

Add a scheduled workflow that will use the latest snapshot toolchain with the
main branch and verify how well it works. Include all of the usual platforms that
are verified in each pull request.