### PR TITLE
Place the correct program and arguments into RunProgramError

### DIFF
--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -338,7 +338,7 @@ extension Platform {
         process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {
-            throw RunProgramError(exitCode: process.terminationStatus, program: args.first!, arguments: Array(args.dropFirst()))
+            throw RunProgramError(exitCode: process.terminationStatus, program: program, arguments: args)
         }
 
         if let outData {


### PR DESCRIPTION
When runProgramOutput produces an error the exit code, program
name, and arguments are captured in a RunProgramError. However,
the program is being set to the first argument instead of the program
name, and the arguments doesn't include that first argument.

Correctly set the program name to the be the program name, and
set the arguments to be the entire argument list so that the error is
clear, and has all of the details.