### PR TITLE
Add support for sudo installation missing packages after init

### DIFF
--- a/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
+++ b/Documentation/SwiftlyDocs.docc/swiftly-cli-reference.md
@@ -405,7 +405,7 @@ written to this file as commands that can be run after the installation.
 Perform swiftly initialization into your user account.
 
 ```
-swiftly init [--no-modify-profile] [--overwrite] [--platform=<platform>] [--skip-install] [--quiet-shell-followup] [--assume-yes] [--verbose] [--version] [--help]
+swiftly init [--no-modify-profile] [--overwrite] [--platform=<platform>] [--skip-install] [--quiet-shell-followup] [--sudo-install-packages] [--assume-yes] [--verbose] [--version] [--help]
 ```
 
 **--no-modify-profile:**
@@ -431,6 +431,11 @@ swiftly init [--no-modify-profile] [--overwrite] [--platform=<platform>] [--skip
 **--quiet-shell-followup:**
 
 *Quiet shell follow up commands*
+
+
+**--sudo-install-packages:**
+
+*Run sudo if there are post-installation packages to install (Linux only)*
 
 
 **--assume-yes:**

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -337,11 +337,11 @@ internal struct Init: SwiftlyCommand {
 
                     p.waitUntilExit()
 
-                    guard p.terminationStatus == 0 else {
-                        throw SwiftlyError(message: "sudo could not be run to install the packages")
+                    if p.terminationStatus == 0 {
+                        SwiftlyCore.print("sudo could not be run to install the packages")
                     }
                 } catch {
-                    throw SwiftlyError(message: "sudo could not be run to install the packages")
+                    SwiftlyCore.print("sudo could not be run to install the packages")
                 }
             }
         }

--- a/Sources/Swiftly/Proxy.swift
+++ b/Sources/Swiftly/Proxy.swift
@@ -24,8 +24,8 @@ public enum Proxy {
 
                     if CommandLine.arguments.count == 1 {
                         // User ran swiftly with no extra arguments in an uninstalled environment, so we jump directly into
-                        //  an simple init.
-                        try await Init.execute(assumeYes: false, noModifyProfile: false, overwrite: false, platform: nil, verbose: false, skipInstall: false, quietShellFollowup: false)
+                        //  a simple init.
+                        try await Init.execute(assumeYes: false, noModifyProfile: false, overwrite: false, platform: nil, verbose: false, skipInstall: false, quietShellFollowup: false, sudoInstallPackages: false)
                         return
                     } else if CommandLine.arguments.count >= 2 && CommandLine.arguments[1] == "init" {
                         // Let the user run the init command with their arguments, if any.

--- a/Tests/SwiftlyTests/InitTests.swift
+++ b/Tests/SwiftlyTests/InitTests.swift
@@ -125,4 +125,15 @@ final class InitTests: SwiftlyTests {
             XCTAssertTrue(Swiftly.currentPlatform.swiftlyToolchainsDir.appendingPathComponent("foo.txt").fileExists())
         }
     }
+
+    func testAllowedInstalledCommands() async throws {
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "apt-get -y install python3 libsqlite3") != nil)
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "yum -y install python3 libsqlite3") != nil)
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "yum -y install python3 libsqlite3-dev") != nil)
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "yum -y install libstdc++-dev:i386") != nil)
+
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "SOME_ENV_VAR=abcde yum -y install libstdc++-dev:i386") == nil)
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "apt-get -y install libstdc++-dev:i386; rm -rf /") == nil)
+        XCTAssertTrue(try Init.allowedInstallCommands.wholeMatch(in: "apt-get -y install libstdc++-dev:i386\nrm -rf /") == nil)
+    }
 }


### PR DESCRIPTION
Currently when there is a post installation command during init the user is given the command that they must run at the end. In order to streamline the process further an additional flag called '--sudo-install-packages' is added that will invoke sudo on behalf of the user to perform that command as root.

Add the new flag to the init subcommand. Create a regex that restricts the allowable commands to a narrow set of patterns as a measure of protection. Invoke the sudo process directly from the expected directory on supported Linux systems, which is /usr/bin/sudo