### PR TITLE
Append file extension to downloaded toolchain

### DIFF
--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -188,7 +188,7 @@ struct Install: SwiftlyCommand {
 
         await ctx.print("Installing \(version)")
 
-        let tmpFile = fs.mktemp()
+        let tmpFile = fs.mktemp(ext: ".\(Swiftly.currentPlatform.toolchainFileExtension)")
         try await fs.create(file: tmpFile, contents: nil)
         return try await fs.withTemporary(files: tmpFile) {
             var platformString = config.platform.name


### PR DESCRIPTION
The `installer` tool fails to install the toolchain on macOS unless `.pkg` is present in the filename. Otherwise it produces the error: "Error - the package path specified was invalid"

Add the appropriate file extension when downloading the toolchain so the installer can use it correctly.