### PR TITLE
Adding FileLock

### DIFF
--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,0 +1,1 @@
+Sources/SwiftlyCore/ProcessInfo.swift

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -357,7 +357,7 @@ struct Install: SwiftlyCommand {
 
             let (pathChanged, newConfig) = try await withLock(lockFile) {
                 if verbose {
-                    await ctx.print("Acquired installation lock.")
+                    await ctx.print("Acquired installation lock")
                 }
 
                 var config = try await Config.load(ctx)

--- a/Sources/SwiftlyCore/FileLock.swift
+++ b/Sources/SwiftlyCore/FileLock.swift
@@ -1,60 +1,49 @@
 import Foundation
 import SystemPackage
 
-/**
- * A non-blocking file lock implementation using file creation as locking mechanism.
- * Use case: When installing multiple Swiftly instances on the same machine,
- * one should acquire the lock while others poll until it becomes available.
- */
+enum FileLockError: Error {
+    case cannotAcquireLock
+    case timeoutExceeded
+}
 
-public actor FileLock {
+/// A non-blocking file lock implementation using file creation as locking mechanism.
+/// Use case: When installing multiple Swiftly instances on the same machine,
+/// one should acquire the lock while others poll until it becomes available.
+public struct FileLock {
     let filePath: FilePath
-    private var isLocked = false
 
     public static let defaultPollingInterval: TimeInterval = 1
     public static let defaultTimeout: TimeInterval = 300.0
 
-    public init(at path: FilePath) {
+    public init(at path: FilePath) throws {
         self.filePath = path
-    }
-
-    public func tryLock() async -> Bool {
         do {
-            guard !self.isLocked else { return true }
-
-            guard !(try await FileSystem.exists(atPath: self.filePath)) else {
-                return false
-            }
-            // Create the lock file with exclusive permissions
-            try await FileSystem.create(.mode(0o600), file: self.filePath, contents: nil)
-            self.isLocked = true
-            return true
-        } catch {
-            return false
+            let fileURL = URL(fileURLWithPath: self.filePath.string)
+            let contents = Foundation.ProcessInfo.processInfo.processIdentifier.description.data(using: .utf8) ?? Data()
+            try contents.write(to: fileURL, options: .withoutOverwriting)
+        } catch CocoaError.fileWriteFileExists {
+            throw FileLockError.cannotAcquireLock
         }
     }
 
-    public func waitForLock(
+    public static func waitForLock(
+        _ path: FilePath,
         timeout: TimeInterval = FileLock.defaultTimeout,
         pollingInterval: TimeInterval = FileLock.defaultPollingInterval
-    ) async -> Bool {
+    ) async throws -> FileLock {
         let start = Date()
-
         while Date().timeIntervalSince(start) < timeout {
-            if await self.tryLock() {
-                return true
+            if let fileLock = try? FileLock(at: path) {
+                return fileLock
             }
             try? await Task.sleep(for: .seconds(pollingInterval))
         }
 
-        return false
+        throw FileLockError.timeoutExceeded
     }
 
     public func unlock() async throws {
-        guard self.isLocked else { return }
-
         try await FileSystem.remove(atPath: self.filePath)
-        self.isLocked = false
     }
 }
 
@@ -64,20 +53,22 @@ public func withLock<T>(
     pollingInterval: TimeInterval = FileLock.defaultPollingInterval,
     action: @escaping () async throws -> T
 ) async throws -> T {
-    let lock = FileLock(at: lockFile)
-    guard await lock.waitForLock(timeout: timeout, pollingInterval: pollingInterval) else {
-        throw SwiftlyError(message: "Failed to acquire file lock at \(lock.filePath)")
+    guard
+        let lock = try? await FileLock.waitForLock(
+            lockFile,
+            timeout: timeout,
+            pollingInterval: pollingInterval
+        )
+    else {
+        throw SwiftlyError(message: "Failed to acquire file lock at \(lockFile)")
     }
 
-    defer {
-        Task {
-            do {
-                try await lock.unlock()
-            } catch {
-                print("WARNING: Failed to unlock file: \(error)")
-            }
-        }
+    do {
+        let result = try await action()
+        try await lock.unlock()
+        return result
+    } catch {
+        try await lock.unlock()
+        throw error
     }
-
-    return try await action()
 }

--- a/Sources/SwiftlyCore/FileLock.swift
+++ b/Sources/SwiftlyCore/FileLock.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/**
+ * A non-blocking file lock implementation with polling capability.
+ * Use case: When installing multiple Swiftly instances on the same machine,
+ * one should acquire the lock while others poll until it becomes available.
+ */
+
+#if os(macOS)
+import Darwin.C
+#elseif os(Linux)
+import Glibc
+#endif
+
+public struct FileLock {
+    let filePath: String
+
+    let fileHandle: FileHandle
+
+    public static let defaultPollingInterval: TimeInterval = 1.0
+
+    public static let defaultTimeout: TimeInterval = 300.0
+
+    public init(at filePath: String) throws {
+        self.filePath = filePath
+
+        if !FileManager.default.fileExists(atPath: filePath) {
+            FileManager.default.createFile(atPath: filePath, contents: nil)
+        }
+
+        self.fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: filePath))
+    }
+
+    public func tryLock() -> Bool {
+        self.fileHandle.tryLockFile()
+    }
+
+    public func waitForLock(
+        timeout: TimeInterval = FileLock.defaultTimeout,
+        pollingInterval: TimeInterval = FileLock.defaultPollingInterval
+    ) -> Bool {
+        let startTime = Date()
+
+        if self.tryLock() {
+            return true
+        }
+
+        while Date().timeIntervalSince(startTime) < timeout {
+            Thread.sleep(forTimeInterval: pollingInterval)
+
+            if self.tryLock() {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    public func unlock() throws {
+        guard self.fileHandle != nil else { return }
+        try self.fileHandle.unlockFile()
+        try self.fileHandle.close()
+    }
+}
+
+extension FileHandle {
+    func tryLockFile() -> Bool {
+        let fd = self.fileDescriptor
+        var flock = flock()
+        flock.l_type = Int16(F_WRLCK)
+        flock.l_whence = Int16(SEEK_SET)
+        flock.l_start = 0
+        flock.l_len = 0
+
+        if fcntl(fd, F_SETLK, &flock) == -1 {
+            if errno == EACCES || errno == EAGAIN {
+                return false
+            } else {
+                fputs("Unexpected lock error: \(String(cString: strerror(errno)))\n", stderr)
+                return false
+            }
+        }
+        return true
+    }
+
+    func unlockFile() throws {
+        let fd = self.fileDescriptor
+        var flock = flock()
+        flock.l_type = Int16(F_UNLCK)
+        flock.l_whence = Int16(SEEK_SET)
+        flock.l_start = 0
+        flock.l_len = 0
+
+        if fcntl(fd, F_SETLK, &flock) == -1 {
+            throw SwiftlyError(
+                message: "Failed to unlock file: \(String(cString: strerror(errno)))")
+        }
+    }
+}

--- a/Sources/SwiftlyCore/ProcessInfo.swift
+++ b/Sources/SwiftlyCore/ProcessInfo.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+#if os(Windows)
+import WinSDK
+#endif
+
+enum ProcessCheckError: Error {
+    case invalidPID
+    case checkFailed
+}
+
+/// Checks if a process is still running by process ID
+/// - Parameter pidString: The process ID
+/// - Returns: true if the process is running, false if it's not running or doesn't exist
+/// - Throws: ProcessCheckError if the check fails or PID is invalid
+public func isProcessRunning(pidString: String) throws -> Bool {
+    guard let pid = Int32(pidString.trimmingCharacters(in: .whitespaces)) else {
+        throw ProcessCheckError.invalidPID
+    }
+
+    return try isProcessRunning(pid: pid)
+}
+
+public func isProcessRunning(pid: Int32) throws -> Bool {
+#if os(macOS) || os(Linux)
+    let result = kill(pid, 0)
+    if result == 0 {
+        return true
+    } else if errno == ESRCH { // No such process
+        return false
+    } else if errno == EPERM { // Operation not permitted, but process exists
+        return true
+    } else {
+        throw ProcessCheckError.checkFailed
+    }
+
+#elseif os(Windows)
+    // On Windows, use OpenProcess to check if process exists
+    let handle = OpenProcess(DWORD(PROCESS_QUERY_LIMITED_INFORMATION), false, DWORD(pid))
+    if handle != nil {
+        CloseHandle(handle)
+        return true
+    } else {
+        let error = GetLastError()
+        if error == ERROR_INVALID_PARAMETER || error == ERROR_NOT_FOUND {
+            return false // Process not found
+        } else {
+            throw ProcessCheckError.checkFailed
+        }
+    }
+
+#else
+    #error("Platform is not supported")
+#endif
+}

--- a/Tests/SwiftlyTests/FileLockTests.swift
+++ b/Tests/SwiftlyTests/FileLockTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import SwiftlyCore
+
+@Suite struct FileLockTests {
+    @Test("FileLock creation writes process ID to lock file")
+    func testFileLockCreation() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "test.lock"
+
+            let lock = try FileLock(at: lockPath)
+
+            // Verify lock file exists
+            #expect(try await fs.exists(atPath: lockPath))
+
+            // Verify lock file contains process ID
+            let lockData = try Data(contentsOf: URL(fileURLWithPath: lockPath.string))
+            let lockContent = String(data: lockData, encoding: .utf8)
+            let expectedPID = Foundation.ProcessInfo.processInfo.processIdentifier.description
+            #expect(lockContent == expectedPID)
+
+            try await lock.unlock()
+        }
+    }
+
+    @Test("FileLock fails when lock file already exists")
+    func testFileLockConflict() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "conflict.lock"
+
+            // Create first lock
+            let firstLock = try FileLock(at: lockPath)
+
+            // Attempt to create second lock should fail
+            do {
+                _ = try FileLock(at: lockPath)
+                #expect(Bool(false), "Expected FileLockError.lockedByPID to be thrown")
+            } catch let error as FileLockError {
+                if case .lockedByPID = error {
+                } else {
+                    #expect(Bool(false), "Expected FileLockError.lockedByPID but got \(error)")
+                }
+            }
+
+            try await firstLock.unlock()
+        }
+    }
+
+    @Test("FileLock unlock removes lock file")
+    func testFileLockUnlock() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "unlock.lock"
+
+            let lock = try FileLock(at: lockPath)
+            #expect(try await fs.exists(atPath: lockPath))
+
+            try await lock.unlock()
+            #expect(!(try await fs.exists(atPath: lockPath)))
+        }
+    }
+
+    @Test("FileLock can be reacquired after unlock")
+    func testFileLockReacquisition() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "reacquire.lock"
+
+            // First acquisition
+            let firstLock = try FileLock(at: lockPath)
+            try await firstLock.unlock()
+
+            // Second acquisition should succeed
+            let secondLock = try FileLock(at: lockPath)
+            try await secondLock.unlock()
+        }
+    }
+
+    @Test("waitForLock succeeds immediately when no lock exists")
+    func testWaitForLockImmediate() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "immediate.lock"
+            let time = Date()
+            let lock = try await FileLock.waitForLock(lockPath, timeout: 1.0, pollingInterval: 0.1)
+            let duration = Date().timeIntervalSince(time)
+            #expect(duration < 1.0)
+            #expect(try await fs.exists(atPath: lockPath))
+            try await lock.unlock()
+        }
+    }
+
+    @Test("waitForLock times out when lock cannot be acquired")
+    func testWaitForLockTimeout() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "timeout.lock"
+
+            // Create existing lock
+            let existingLock = try FileLock(at: lockPath)
+
+            // Attempt to wait for lock should timeout
+            do {
+                _ = try await FileLock.waitForLock(lockPath, timeout: 0.5, pollingInterval: 0.1)
+                #expect(Bool(false), "Expected FileLockError.lockedByPID to be thrown")
+            } catch let error as FileLockError {
+                if case .lockedByPID = error {
+                    // Expected error
+                } else {
+                    #expect(Bool(false), "Expected FileLockError.lockedByPID but got \(error)")
+                }
+            }
+
+            try await existingLock.unlock()
+        }
+    }
+
+    @Test("waitForLock succeeds when lock becomes available")
+    func testWaitForLockEventualSuccess() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "eventual.lock"
+
+            // Create initial lock
+            let initialLock = try FileLock(at: lockPath)
+            // Start waiting for lock in background task
+            let waitTask = Task {
+                try await Task.sleep(for: .seconds(0.1))
+                let waitingLock = try await FileLock.waitForLock(
+                    lockPath,
+                    timeout: 2.0,
+                    pollingInterval: 0.1
+                )
+                try await waitingLock.unlock()
+                return true
+            }
+            // Release initial lock after delay
+            try await Task.sleep(for: .seconds(0.3))
+            try await initialLock.unlock()
+            // Wait for the waiting task to complete
+            let result = try await waitTask.value
+            #expect(result, "Lock wait operation should succeed")
+        }
+    }
+
+    @Test("withLock executes action and automatically unlocks")
+    func testWithLockSuccess() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "withlock.lock"
+            var actionExecuted = false
+
+            let result = try await withLock(lockPath, timeout: 1.0, pollingInterval: 0.1) {
+                actionExecuted = true
+                return "success"
+            }
+
+            #expect(actionExecuted)
+            #expect(result == "success")
+            #expect(!(try await fs.exists(atPath: lockPath)))
+        }
+    }
+
+    @Test("withLock unlocks even when action throws")
+    func testWithLockErrorHandling() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "withlockError.lock"
+
+            struct TestError: Error {}
+
+            await #expect(throws: TestError.self) {
+                try await withLock(lockPath, timeout: 1.0, pollingInterval: 0.1) {
+                    throw TestError()
+                }
+            }
+
+            // Lock should be released even after error
+            let exists = try await fs.exists(atPath: lockPath)
+            #expect(!exists)
+        }
+    }
+
+    @Test("withLock fails when lock cannot be acquired within timeout")
+    func testWithLockTimeout() async throws {
+        try await SwiftlyTests.withTestHome {
+            let lockPath = SwiftlyTests.ctx.mockedHomeDir! / "withlockTimeout.lock"
+
+            // Create existing lock
+            let existingLock = try FileLock(at: lockPath)
+
+            await #expect(throws: SwiftlyError.self) {
+                try await withLock(lockPath, timeout: 0.5, pollingInterval: 0.1) {
+                    "should not execute"
+                }
+            }
+
+            try await existingLock.unlock()
+        }
+    }
+}


### PR DESCRIPTION
Fixes Issue #142 

- **Description**:
Serialize concurrent swiftly install commands with a simple file lock.
Adds a lightweight FileLock (using `Data.write(to: fileURL, options: .withoutOverwriting)`) and wraps the install routine so only one process installs at a time

