### PR TITLE
Do not move symlink swiftly into the bin directory

### DIFF
--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -373,7 +373,7 @@ extension Platform {
 
         // We couldn't find ourselves in the usual places. Assume that no installation is necessary
         // since we were most likely invoked at SWIFTLY_BIN_DIR already.
-        guard var cmdAbsolute else {
+        guard let cmdAbsolute else {
             return
         }
 
@@ -381,8 +381,6 @@ extension Platform {
         if let _ = try? FileManager.default.destinationOfSymbolicLink(atPath: cmdAbsolute) {
             return
         }
-
-        guard case let cmdAbsolute = cmdAbsolute else { fatalError() }
 
         // Proceed to installation only if we're in the user home directory, or a non-system location.
         let userHome = fs.home


### PR DESCRIPTION
If the swiftly that we've found is a symbolic link then there is likely a
sophisticated installation of it, such as with homebrew. Don't copy
that symbolic link to the bin directory in this case, and allow the
external manager to manage swiftly upgrades on its own.