### PR TITLE
Find symlink managed swiftly when creating proxies

### DIFF
--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -450,6 +450,13 @@ extension Platform {
             return swiftlyHomeBin
         }
 
+        // If swiftly is a symlink then something else, such as homebrew, is managing it.
+        if cmdAbsolute != nil {
+            if let _ = try? FileManager.default.destinationOfSymbolicLink(atPath: cmdAbsolute!) {
+                return cmdAbsolute
+            }
+        }
+
         let systemRoots: [FilePath] = ["/usr", "/opt", "/bin"]
 
         // If we are system managed then we know where swiftly should be.


### PR DESCRIPTION
When swiftly is being invoked through a symlink, like what happens with
homebrew, then it should be able to create proxies that point to the swiftly
symlink that is on the path. That symlink is updated whenever swiftly is
upgraded in this environment.

Change the find swiftly binary code to account for this case and return
the absolute path to the swiftly symlink for proxy creation.