### PR TITLE
Refactoring output print to message

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -342,7 +342,7 @@ public struct Linux: Platform {
             try await fs.mkdir(atPath: self.swiftlyToolchainsDir(ctx))
         }
 
-        await ctx.print("Extracting toolchain...")
+        await ctx.message("Extracting toolchain...")
         let toolchainDir = self.swiftlyToolchainsDir(ctx) / version.name
 
         if try await fs.exists(atPath: toolchainDir) {
@@ -376,7 +376,7 @@ public struct Linux: Platform {
         let tmpDir = self.getTempFilePath()
         try await fs.mkdir(.parents, atPath: tmpDir)
         try await fs.withTemporary(files: tmpDir) {
-            await ctx.print("Extracting new swiftly...")
+            await ctx.message("Extracting new swiftly...")
             try extractArchive(atPath: archive) { name in
                 // Extract to the temporary directory
                 tmpDir / String(name)
@@ -405,7 +405,7 @@ public struct Linux: Platform {
         _ ctx: SwiftlyCoreContext, toolchainFile: ToolchainFile, archive: FilePath, verbose: Bool
     ) async throws {
         if verbose {
-            await ctx.print("Downloading toolchain signature...")
+            await ctx.message("Downloading toolchain signature...")
         }
 
         let sigFile = self.getTempFilePath()
@@ -413,7 +413,7 @@ public struct Linux: Platform {
         try await fs.withTemporary(files: sigFile) {
             try await ctx.httpClient.getSwiftToolchainFileSignature(toolchainFile).download(to: sigFile)
 
-            await ctx.print("Verifying toolchain signature...")
+            await ctx.message("Verifying toolchain signature...")
             do {
                 if let mockedHomeDir = ctx.mockedHomeDir {
                     var env = ProcessInfo.processInfo.environment
@@ -432,7 +432,7 @@ public struct Linux: Platform {
         _ ctx: SwiftlyCoreContext, archiveDownloadURL: URL, archive: FilePath, verbose: Bool
     ) async throws {
         if verbose {
-            await ctx.print("Downloading swiftly signature...")
+            await ctx.message("Downloading swiftly signature...")
         }
 
         let sigFile = self.getTempFilePath()
@@ -442,7 +442,7 @@ public struct Linux: Platform {
                 url: archiveDownloadURL.appendingPathExtension("sig")
             ).download(to: sigFile)
 
-            await ctx.print("Verifying swiftly signature...")
+            await ctx.message("Verifying swiftly signature...")
             do {
                 if let mockedHomeDir = ctx.mockedHomeDir {
                     var env = ProcessInfo.processInfo.environment
@@ -461,11 +461,11 @@ public struct Linux: Platform {
         -> PlatformDefinition
     {
         if let platformPretty {
-            print(
+            await ctx.message(
                 "\(platformPretty) is not an officially supported platform, but the toolchains for another platform may still work on it."
             )
         } else {
-            print(
+            await ctx.message(
                 "This platform could not be detected, but a toolchain for one of the supported platforms may work on it."
             )
         }
@@ -473,7 +473,7 @@ public struct Linux: Platform {
         let selections = self.linuxPlatforms.enumerated().map { "\($0 + 1)) \($1.namePretty)" }.joined(
             separator: "\n")
 
-        print(
+        await ctx.message(
             """
             Please select the platform to use for toolchain downloads:
 
@@ -526,7 +526,7 @@ public struct Linux: Platform {
             if disableConfirmation {
                 throw SwiftlyError(message: message)
             } else {
-                print(message)
+                await ctx.message(message)
             }
             return await self.manualSelectPlatform(ctx, platformPretty)
         }
@@ -557,7 +557,7 @@ public struct Linux: Platform {
             if disableConfirmation {
                 throw SwiftlyError(message: message)
             } else {
-                print(message)
+                await ctx.message(message)
             }
             return await self.manualSelectPlatform(ctx, platformPretty)
         }
@@ -568,7 +568,7 @@ public struct Linux: Platform {
                 if disableConfirmation {
                     throw SwiftlyError(message: message)
                 } else {
-                    print(message)
+                    await ctx.message(message)
                 }
                 return await self.manualSelectPlatform(ctx, platformPretty)
             }
@@ -580,7 +580,7 @@ public struct Linux: Platform {
                 if disableConfirmation {
                     throw SwiftlyError(message: message)
                 } else {
-                    print(message)
+                    await ctx.message(message)
                 }
                 return await self.manualSelectPlatform(ctx, platformPretty)
             }
@@ -596,7 +596,7 @@ public struct Linux: Platform {
         if disableConfirmation {
             throw SwiftlyError(message: message)
         } else {
-            print(message)
+            await ctx.message(message)
         }
         return await self.manualSelectPlatform(ctx, platformPretty)
     }

--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -69,12 +69,12 @@ public struct MacOS: Platform {
 
         if toolchainsDir == self.defaultToolchainsDirectory {
             // If the toolchains go into the default user location then we use the installer to install them
-            await ctx.print("Installing package in user home directory...")
+            await ctx.message("Installing package in user home directory...")
 
             try await sys.installer(.verbose, .pkg(tmpFile), .target("CurrentUserHomeDirectory")).run(self, quiet: !verbose)
         } else {
             // Otherwise, we extract the pkg into the requested toolchains directory.
-            await ctx.print("Expanding pkg...")
+            await ctx.message("Expanding pkg...")
             let tmpDir = fs.mktemp()
             let toolchainDir = toolchainsDir / "\(version.identifier).xctoolchain"
 
@@ -82,7 +82,7 @@ public struct MacOS: Platform {
                 try await fs.mkdir(atPath: toolchainDir)
             }
 
-            await ctx.print("Checking package signature...")
+            await ctx.message("Checking package signature...")
             do {
                 try await sys.pkgutil().checksignature(pkg_path: tmpFile).run(self, quiet: !verbose)
             } catch {
@@ -92,7 +92,7 @@ public struct MacOS: Platform {
                 }
 
                 // We permit the signature verification to fail during testing
-                await ctx.print("Signature verification failed, which is allowable during testing with mocked toolchains")
+                await ctx.message("Signature verification failed, which is allowable during testing with mocked toolchains")
             }
             try await sys.pkgutil(.verbose).expand(pkg_path: tmpFile, dir_path: tmpDir).run(self, quiet: !verbose)
 
@@ -103,7 +103,7 @@ public struct MacOS: Platform {
                 payload = tmpDir / "\(version.identifier)-osx-package.pkg/Payload"
             }
 
-            await ctx.print("Untarring pkg Payload...")
+            await ctx.message("Untarring pkg Payload...")
             try await sys.tar(.directory(toolchainDir)).extract(.verbose, .archive(payload)).run(self, quiet: !verbose)
         }
     }
@@ -116,7 +116,7 @@ public struct MacOS: Platform {
         let userHomeDir = ctx.mockedHomeDir ?? fs.home
 
         if ctx.mockedHomeDir == nil {
-            await ctx.print("Extracting the swiftly package...")
+            await ctx.message("Extracting the swiftly package...")
             try await sys.installer(
                 .pkg(archive),
                 .target("CurrentUserHomeDirectory")
@@ -138,7 +138,7 @@ public struct MacOS: Platform {
                 throw SwiftlyError(message: "Payload file could not be found at \(tmpDir).")
             }
 
-            await ctx.print("Extracting the swiftly package into \(installDir)...")
+            await ctx.message("Extracting the swiftly package into \(installDir)...")
             try await sys.tar(.directory(installDir)).extract(.verbose, .archive(payload)).run(self, quiet: false)
         }
 
@@ -149,7 +149,7 @@ public struct MacOS: Platform {
         async throws
     {
         if verbose {
-            await ctx.print("Uninstalling package in user home directory... ")
+            await ctx.message("Uninstalling package in user home directory... ")
         }
 
         let toolchainDir = self.swiftlyToolchainsDir(ctx) / "\(toolchain.identifier).xctoolchain"

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -124,7 +124,7 @@ struct Init: SwiftlyCommand {
                 """
             }
 
-            await ctx.print(msg)
+            await ctx.message(msg)
 
             guard await ctx.promptForConfirmation(defaultBehavior: true) else {
                 throw SwiftlyError(message: "swiftly installation has been cancelled")
@@ -193,7 +193,7 @@ struct Init: SwiftlyCommand {
         let envFileExists = try await fs.exists(atPath: envFile)
 
         if overwrite || !envFileExists {
-            await ctx.print("Creating shell environment file for the user...")
+            await ctx.message("Creating shell environment file for the user...")
             var env = ""
             if shell.hasSuffix("fish") {
                 env = """
@@ -221,7 +221,7 @@ struct Init: SwiftlyCommand {
         }
 
         if !noModifyProfile {
-            await ctx.print("Updating profile...")
+            await ctx.message("Updating profile...")
 
             let userHome = ctx.mockedHomeDir ?? fs.home
 
@@ -275,7 +275,7 @@ struct Init: SwiftlyCommand {
         }
 
         if !quietShellFollowup {
-            await ctx.print("""
+            await ctx.message("""
             To begin using installed swiftly from your current shell, first run the following command:
                 \(sourceLine)
 
@@ -284,7 +284,7 @@ struct Init: SwiftlyCommand {
 
         // Fish doesn't have path caching, so this might only be needed for bash/zsh
         if pathChanged && !quietShellFollowup && !shell.hasSuffix("fish") {
-            await ctx.print("""
+            await ctx.message("""
             Your shell caches items on your path for better performance. Swiftly has added
             items to your path that may not get picked up right away. You can update your
             shell's environment by running
@@ -297,7 +297,7 @@ struct Init: SwiftlyCommand {
         }
 
         if let postInstall {
-            await ctx.print(Messages.postInstall(postInstall))
+            await ctx.message(Messages.postInstall(postInstall))
         }
     }
 }

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -115,7 +115,7 @@ struct Install: SwiftlyCommand {
 
         // Fish doesn't cache its path, so this instruction is not necessary.
         if pathChanged && !shell.hasSuffix("fish") {
-            await ctx.print(
+            await ctx.message(
                 """
                 NOTE: Swiftly has updated some elements in your path and your shell may not yet be
                 aware of the changes. You can update your shell's environment by running
@@ -177,10 +177,10 @@ struct Install: SwiftlyCommand {
             let overwrite = Set(toolchainBinDirContents).subtracting(existingProxies).intersection(
                 swiftlyBinDirContents)
             if !overwrite.isEmpty && !assumeYes {
-                await ctx.print("The following existing executables will be overwritten:")
+                await ctx.message("The following existing executables will be overwritten:")
 
                 for executable in overwrite {
-                    await ctx.print("  \(swiftlyBinDir / executable)")
+                    await ctx.message("  \(swiftlyBinDir / executable)")
                 }
 
                 guard await ctx.promptForConfirmation(defaultBehavior: false) else {
@@ -189,7 +189,7 @@ struct Install: SwiftlyCommand {
             }
 
             if verbose {
-                await ctx.print("Setting up toolchain proxies...")
+                await ctx.message("Setting up toolchain proxies...")
             }
 
             let proxiesToCreate = Set(toolchainBinDirContents).subtracting(swiftlyBinDirContents).union(
@@ -251,7 +251,7 @@ struct Install: SwiftlyCommand {
         assumeYes: Bool
     ) async throws -> (postInstall: String?, pathChanged: Bool) {
         guard !config.installedToolchains.contains(version) else {
-            await ctx.print("\(version) is already installed.")
+            await ctx.message("\(version) is already installed.")
             return (nil, false)
         }
 
@@ -263,7 +263,7 @@ struct Install: SwiftlyCommand {
             requireSignatureValidation: verifySignature
         )
 
-        await ctx.print("Installing \(version)")
+        await ctx.message("Installing \(version)")
 
         let tmpFile = fs.mktemp(ext: ".\(Swiftly.currentPlatform.toolchainFileExtension)")
         try await fs.create(file: tmpFile, contents: nil)
@@ -352,12 +352,12 @@ struct Install: SwiftlyCommand {
 
             let lockFile = Swiftly.currentPlatform.swiftlyHomeDir(ctx) / "swiftly.lock"
             if verbose {
-                await ctx.print("Attempting to acquire installation lock at \(lockFile) ...")
+                await ctx.message("Attempting to acquire installation lock at \(lockFile) ...")
             }
 
             let (pathChanged, newConfig) = try await withLock(lockFile) {
                 if verbose {
-                    await ctx.print("Acquired installation lock")
+                    await ctx.message("Acquired installation lock")
                 }
 
                 var config = try await Config.load(ctx)
@@ -390,12 +390,12 @@ struct Install: SwiftlyCommand {
                 if config.inUse == nil {
                     config.inUse = version
                     try config.save(ctx)
-                    await ctx.print("The global default toolchain has been set to `\(version)`")
+                    await ctx.message("The global default toolchain has been set to `\(version)`")
                 }
                 return (pathChanged, config)
             }
             config = newConfig
-            await ctx.print("\(version) installed successfully!")
+            await ctx.message("\(version) installed successfully!")
             return (postInstallScript, pathChanged)
         }
     }
@@ -406,7 +406,7 @@ struct Install: SwiftlyCommand {
     {
         switch selector {
         case .latest:
-            await ctx.print("Fetching the latest stable Swift release...")
+            await ctx.message("Fetching the latest stable Swift release...")
 
             guard
                 let release = try await ctx.httpClient.getReleaseToolchains(
@@ -429,7 +429,7 @@ struct Install: SwiftlyCommand {
                 return .stable(ToolchainVersion.StableRelease(major: major, minor: minor, patch: patch))
             }
 
-            await ctx.print("Fetching the latest stable Swift \(major).\(minor) release...")
+            await ctx.message("Fetching the latest stable Swift \(major).\(minor) release...")
             // If a patch was not provided, perform a lookup to get the latest patch release
             // of the provided major/minor version pair.
             let toolchain = try await ctx.httpClient.getReleaseToolchains(
@@ -449,7 +449,7 @@ struct Install: SwiftlyCommand {
                 return ToolchainVersion(snapshotBranch: branch, date: date)
             }
 
-            await ctx.print("Fetching the latest \(branch) branch snapshot...")
+            await ctx.message("Fetching the latest \(branch) branch snapshot...")
 
             // If a date was not provided, perform a lookup to find the most recent snapshot
             // for the given branch.

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -43,13 +43,13 @@ struct Link: SwiftlyCommand {
         )
 
         if pathChanged {
-            await ctx.print("""
+            await ctx.message("""
             Linked swiftly to Swift \(toolchainVersion.name).
 
             \(Messages.refreshShell)
             """)
         } else {
-            await ctx.print("""
+            await ctx.message("""
             Swiftly is already linked to Swift \(toolchainVersion.name).
             """)
         }

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -59,7 +59,7 @@ struct List: SwiftlyCommand {
             if toolchain == config.inUse {
                 message += " (default)"
             }
-            await ctx.print(message)
+            await ctx.message(message)
         }
 
         if let selector {
@@ -79,14 +79,14 @@ struct List: SwiftlyCommand {
             }
 
             let message = "Installed \(modifier) toolchains"
-            await ctx.print(message)
-            await ctx.print(String(repeating: "-", count: message.count))
+            await ctx.message(message)
+            await ctx.message(String(repeating: "-", count: message.count))
             for toolchain in toolchains {
                 await printToolchain(toolchain)
             }
         } else {
-            await ctx.print("Installed release toolchains")
-            await ctx.print("----------------------------")
+            await ctx.message("Installed release toolchains")
+            await ctx.message("----------------------------")
             for toolchain in toolchains {
                 guard toolchain.isStableRelease() else {
                     continue
@@ -94,9 +94,9 @@ struct List: SwiftlyCommand {
                 await printToolchain(toolchain)
             }
 
-            await ctx.print("")
-            await ctx.print("Installed snapshot toolchains")
-            await ctx.print("-----------------------------")
+            await ctx.message("")
+            await ctx.message("Installed snapshot toolchains")
+            await ctx.message("-----------------------------")
             for toolchain in toolchains where toolchain.isSnapshot() {
                 await printToolchain(toolchain)
             }

--- a/Sources/Swiftly/ListAvailable.swift
+++ b/Sources/Swiftly/ListAvailable.swift
@@ -87,7 +87,7 @@ struct ListAvailable: SwiftlyCommand {
             if toolchain == config.inUse {
                 message += " (default)"
             }
-            await ctx.print(message)
+            await ctx.message(message)
         }
 
         if let selector {
@@ -107,14 +107,14 @@ struct ListAvailable: SwiftlyCommand {
             }
 
             let message = "Available \(modifier) toolchains"
-            await ctx.print(message)
-            await ctx.print(String(repeating: "-", count: message.count))
+            await ctx.message(message)
+            await ctx.message(String(repeating: "-", count: message.count))
             for toolchain in toolchains {
                 await printToolchain(toolchain)
             }
         } else {
-            print("Available release toolchains")
-            print("----------------------------")
+            await ctx.message("Available release toolchains")
+            await ctx.message("----------------------------")
             for toolchain in toolchains where toolchain.isStableRelease() {
                 await printToolchain(toolchain)
             }

--- a/Sources/Swiftly/Proxy.swift
+++ b/Sources/Swiftly/Proxy.swift
@@ -74,10 +74,10 @@ public enum Proxy {
         } catch let terminated as RunProgramError {
             exit(terminated.exitCode)
         } catch let error as SwiftlyError {
-            await ctx.print(error.message)
+            await ctx.message(error.message)
             exit(1)
         } catch {
-            await ctx.print("\(error)")
+            await ctx.message("\(error)")
             exit(1)
         }
     }

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -37,12 +37,12 @@ struct SelfUpdate: SwiftlyCommand {
     public static func execute(_ ctx: SwiftlyCoreContext, verbose: Bool) async throws
         -> SwiftlyVersion
     {
-        await ctx.print("Checking for swiftly updates...")
+        await ctx.message("Checking for swiftly updates...")
 
         let swiftlyRelease = try await ctx.httpClient.getCurrentSwiftlyRelease()
 
         guard try swiftlyRelease.swiftlyVersion > SwiftlyCore.version else {
-            await ctx.print("Already up to date.")
+            await ctx.message("Already up to date.")
             return SwiftlyCore.version
         }
 
@@ -74,7 +74,7 @@ struct SelfUpdate: SwiftlyCommand {
 
         let version = try swiftlyRelease.swiftlyVersion
 
-        await ctx.print("A new version is available: \(version)")
+        await ctx.message("A new version is available: \(version)")
 
         let tmpFile = fs.mktemp()
         try await fs.create(file: tmpFile, contents: nil)
@@ -109,7 +109,7 @@ struct SelfUpdate: SwiftlyCommand {
             )
             try await Swiftly.currentPlatform.extractSwiftlyAndInstall(ctx, from: tmpFile)
 
-            await ctx.print("Successfully updated swiftly to \(version) (was \(SwiftlyCore.version))")
+            await ctx.message("Successfully updated swiftly to \(version) (was \(SwiftlyCore.version))")
             return version
         }
     }

--- a/Sources/Swiftly/Uninstall.swift
+++ b/Sources/Swiftly/Uninstall.swift
@@ -73,24 +73,24 @@ struct Uninstall: SwiftlyCommand {
         }
 
         guard !toolchains.isEmpty else {
-            await ctx.print("No toolchains matched \"\(self.toolchain)\"")
+            await ctx.message("No toolchains matched \"\(self.toolchain)\"")
             return
         }
 
         if !self.root.assumeYes {
-            await ctx.print("The following toolchains will be uninstalled:")
+            await ctx.message("The following toolchains will be uninstalled:")
 
             for toolchain in toolchains {
-                await ctx.print("  \(toolchain)")
+                await ctx.message("  \(toolchain)")
             }
 
             guard await ctx.promptForConfirmation(defaultBehavior: true) else {
-                await ctx.print("Aborting uninstall")
+                await ctx.message("Aborting uninstall")
                 return
             }
         }
 
-        await ctx.print()
+        await ctx.message()
 
         for toolchain in toolchains {
             var config = try await Config.load(ctx)
@@ -124,18 +124,18 @@ struct Uninstall: SwiftlyCommand {
             try await Self.execute(ctx, toolchain, &config, verbose: self.root.verbose)
         }
 
-        await ctx.print()
-        await ctx.print("\(toolchains.count) toolchain(s) successfully uninstalled")
+        await ctx.message()
+        await ctx.message("\(toolchains.count) toolchain(s) successfully uninstalled")
     }
 
     static func execute(
         _ ctx: SwiftlyCoreContext, _ toolchain: ToolchainVersion, _ config: inout Config,
         verbose: Bool
     ) async throws {
-        await ctx.print("Uninstalling \(toolchain)... ", terminator: "")
+        await ctx.message("Uninstalling \(toolchain)... ", terminator: "")
         let lockFile = Swiftly.currentPlatform.swiftlyHomeDir(ctx) / "swiftly.lock"
         if verbose {
-            await ctx.print("Attempting to acquire installation lock at \(lockFile) ...")
+            await ctx.message("Attempting to acquire installation lock at \(lockFile) ...")
         }
 
         config = try await withLock(lockFile) {
@@ -150,6 +150,6 @@ struct Uninstall: SwiftlyCommand {
             try await Swiftly.currentPlatform.uninstall(ctx, toolchain, verbose: verbose)
             return config
         }
-        await ctx.print("done")
+        await ctx.message("done")
     }
 }

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -44,8 +44,8 @@ struct Unlink: SwiftlyCommand {
         }
 
         if pathChanged {
-            await ctx.print(Messages.unlinkSuccess)
-            await ctx.print(Messages.refreshShell)
+            await ctx.message(Messages.unlinkSuccess)
+            await ctx.message(Messages.refreshShell)
         }
     }
 
@@ -71,7 +71,7 @@ extension SwiftlyCommand {
     /// - Parameter ctx: The Swiftly context.
     func validateLinked(_ ctx: SwiftlyCoreContext) async throws {
         if try await !self.isLinked(ctx) {
-            await ctx.print(Messages.currentlyUnlinked)
+            await ctx.message(Messages.currentlyUnlinked)
         }
     }
 

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -92,27 +92,27 @@ struct Update: SwiftlyCommand {
         var config = try await Config.load(ctx)
         guard let parameters = try await self.resolveUpdateParameters(ctx, &config) else {
             if let toolchain = self.toolchain {
-                await ctx.print("No installed toolchain matched \"\(toolchain)\"")
+                await ctx.message("No installed toolchain matched \"\(toolchain)\"")
             } else {
-                await ctx.print("No toolchains are currently installed")
+                await ctx.message("No toolchains are currently installed")
             }
             return
         }
 
         guard let newToolchain = try await self.lookupNewToolchain(ctx, config, parameters) else {
-            await ctx.print("\(parameters.oldToolchain) is already up to date")
+            await ctx.message("\(parameters.oldToolchain) is already up to date")
             return
         }
 
         guard !config.installedToolchains.contains(newToolchain) else {
-            await ctx.print("The newest version of \(parameters.oldToolchain) (\(newToolchain)) is already installed")
+            await ctx.message("The newest version of \(parameters.oldToolchain) (\(newToolchain)) is already installed")
             return
         }
 
         if !self.root.assumeYes {
-            await ctx.print("Update \(parameters.oldToolchain) -> \(newToolchain)?")
+            await ctx.message("Update \(parameters.oldToolchain) -> \(newToolchain)?")
             guard await ctx.promptForConfirmation(defaultBehavior: true) else {
-                await ctx.print("Aborting")
+                await ctx.message("Aborting")
                 return
             }
         }
@@ -128,7 +128,7 @@ struct Update: SwiftlyCommand {
         )
 
         try await Uninstall.execute(ctx, parameters.oldToolchain, &config, verbose: self.root.verbose)
-        await ctx.print("Successfully updated \(parameters.oldToolchain) ⟶ \(newToolchain)")
+        await ctx.message("Successfully updated \(parameters.oldToolchain) ⟶ \(newToolchain)")
 
         if let postInstallScript {
             guard let postInstallFile = self.postInstallFile else {
@@ -146,7 +146,7 @@ struct Update: SwiftlyCommand {
         }
 
         if pathChanged {
-            await ctx.print(Messages.refreshShell)
+            await ctx.message(Messages.refreshShell)
         }
     }
 

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -85,7 +85,7 @@ struct Use: SwiftlyCommand {
 
             if self.printLocation {
                 // Print the toolchain location and exit
-                await ctx.print("\(Swiftly.currentPlatform.findToolchainLocation(ctx, selectedVersion))")
+                await ctx.message("\(Swiftly.currentPlatform.findToolchainLocation(ctx, selectedVersion))")
                 return
             }
 
@@ -98,7 +98,7 @@ struct Use: SwiftlyCommand {
                 message += " (default)"
             }
 
-            await ctx.print(message)
+            await ctx.message(message)
 
             return
         }
@@ -110,7 +110,7 @@ struct Use: SwiftlyCommand {
         let selector = try ToolchainSelector(parsing: toolchain)
 
         guard let toolchain = config.listInstalledToolchains(selector: selector).max() else {
-            await ctx.print("No installed toolchains match \"\(toolchain)\"")
+            await ctx.message("No installed toolchains match \"\(toolchain)\"")
             return
         }
 
@@ -130,10 +130,10 @@ struct Use: SwiftlyCommand {
             message = "The file `\(versionFile)` has been set to `\(toolchain)`"
         } else if let newVersionFile = try await findNewVersionFile(ctx), !globalDefault {
             if !assumeYes {
-                await ctx.print("A new file `\(newVersionFile)` will be created to set the new in-use toolchain for this project. Alternatively, you can set your default globally with the `--global-default` flag. Proceed with creating this file?")
+                await ctx.message("A new file `\(newVersionFile)` will be created to set the new in-use toolchain for this project. Alternatively, you can set your default globally with the `--global-default` flag. Proceed with creating this file?")
 
                 guard await ctx.promptForConfirmation(defaultBehavior: true) else {
-                    await ctx.print("Aborting setting in-use toolchain")
+                    await ctx.message("Aborting setting in-use toolchain")
                     return
                 }
             }
@@ -151,7 +151,7 @@ struct Use: SwiftlyCommand {
             message += " (was \(selectedVersion.name))"
         }
 
-        await ctx.print(message)
+        await ctx.message(message)
     }
 
     static func findNewVersionFile(_ ctx: SwiftlyCoreContext) async throws -> FilePath? {

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -404,7 +404,7 @@ extension Platform {
             return
         }
 
-        await ctx.print("Installing swiftly in \(swiftlyHomeBin)...")
+        await ctx.message("Installing swiftly in \(swiftlyHomeBin)...")
 
         if try await fs.exists(atPath: swiftlyHomeBin) {
             try await fs.remove(atPath: swiftlyHomeBin)
@@ -414,7 +414,7 @@ extension Platform {
             try await fs.move(atPath: cmdAbsolute, toPath: swiftlyHomeBin)
         } catch {
             try await fs.copy(atPath: cmdAbsolute, toPath: swiftlyHomeBin)
-            await ctx.print(
+            await ctx.message(
                 "Swiftly has been copied into the installation directory. You can remove '\(cmdAbsolute)'. It is no longer needed."
             )
         }

--- a/Sources/SwiftlyCore/SwiftlyCore.swift
+++ b/Sources/SwiftlyCore/SwiftlyCore.swift
@@ -53,19 +53,22 @@ public struct SwiftlyCoreContext: Sendable {
     /// Pass the provided string to the set output handler if any.
     /// If no output handler has been set, just print to stdout.
     public func print(_ string: String = "", terminator: String? = nil) async {
-        // Get terminal size or use default width
-        let terminalWidth = self.getTerminalWidth()
-        let wrappedString = string.isEmpty ? string : string.wrapText(to: terminalWidth)
-
         guard let handler = self.outputHandler else {
             if let terminator {
-                Swift.print(wrappedString, terminator: terminator)
+                Swift.print(string, terminator: terminator)
             } else {
-                Swift.print(wrappedString)
+                Swift.print(string)
             }
             return
         }
-        await handler.handleOutputLine(wrappedString + (terminator ?? ""))
+        await handler.handleOutputLine(string + (terminator ?? ""))
+    }
+
+    public func message(_ string: String = "", terminator: String? = nil) async {
+        // Get terminal size or use default width
+        let terminalWidth = self.getTerminalWidth()
+        let wrappedString = string.isEmpty ? string : string.wrapText(to: terminalWidth)
+        await self.print(wrappedString, terminator: terminator)
     }
 
     /// Detects the terminal width in columns


### PR DESCRIPTION
Fixes Issue: #378 

To control printing user facing messages to stdout or stderr created a new function `message` to internally delegate to print after formatting.

In a subsequent change we will control the output to stdout or stderr.