### PR TITLE
Tests: Disable Git Commit Signing in Tests

### DIFF
--- a/Tests/SwiftlyTests/CommandLineTests.swift
+++ b/Tests/SwiftlyTests/CommandLineTests.swift
@@ -95,7 +95,8 @@ public struct CommandLineTests {
         // AND a simple history
         try "Some text".write(to: tmp / "foo.txt", atomically: true)
         try await Swiftly.currentPlatform.runProgram("git", "-C", "\(tmp)", "add", "foo.txt")
-        try await Swiftly.currentPlatform.runProgram("git", "-C", "\(tmp)", "config", "user.email", "user@example.com")
+        try await Swiftly.currentPlatform.runProgram("git", "-C", "\(tmp)", "config", "--local", "user.email", "user@example.com")
+        try await Swiftly.currentPlatform.runProgram("git", "-C", "\(tmp)", "config", "--local", "commit.gpgsign", "false")
         try await sys.git(.workingDir(tmp)).commit(.message("Initial commit")).run(Swiftly.currentPlatform)
         try await sys.git(.workingDir(tmp)).diffindex(.quiet, tree_ish: "HEAD").run(Swiftly.currentPlatform)
 


### PR DESCRIPTION
The test suite creates a tiny test suite with a custom user email. If a developer working on Swiftly has commit signing enabled, that tool will see that the committer email and the signing identity don't match, and will fail to sign the commit, causing the `testGit` test to fail.

Disabling gpg signing commits in the temporary test repo.