### PR TITLE
Partial warning cleanup: remove unused awaits and refactor argument parsing

### DIFF
--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -117,7 +117,7 @@ public struct MacOS: Platform {
 
         if ctx.mockedHomeDir == nil {
             await ctx.message("Extracting the swiftly package...")
-            sys.installer(
+            _ = sys.installer(
                 .pkg(archive),
                 .target("CurrentUserHomeDirectory")
             )
@@ -193,7 +193,7 @@ public struct MacOS: Platform {
     }
 
     public func getShell() async throws -> String {
-        for (key, value) in try await sys.dscl(datasource: ".").read(path: fs.home, key: ["UserShell"]).properties(self) {
+        for (_, value) in try await sys.dscl(datasource: ".").read(path: fs.home, key: ["UserShell"]).properties(self) {
             return value
         }
 

--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -117,7 +117,7 @@ public struct MacOS: Platform {
 
         if ctx.mockedHomeDir == nil {
             await ctx.message("Extracting the swiftly package...")
-            try await sys.installer(
+            sys.installer(
                 .pkg(archive),
                 .target("CurrentUserHomeDirectory")
             )

--- a/Sources/SwiftlyCore/ModeledCommandLine.swift
+++ b/Sources/SwiftlyCore/ModeledCommandLine.swift
@@ -181,7 +181,7 @@ extension Runnable {
             newEnv = newValue
         }
 
-        try await p.runProgram([executable] + args, quiet: quiet, env: newEnv)
+        try p.runProgram([executable] + args, quiet: quiet, env: newEnv)
     }
 }
 

--- a/Tools/generate-command-models/GenerateCommandModels.swift
+++ b/Tools/generate-command-models/GenerateCommandModels.swift
@@ -70,7 +70,7 @@ struct GenerateCommandModels: AsyncParsableCommand {
             """
         }
 
-        try await allCmds.write(to: URL(fileURLWithPath: self.outputFile), atomically: true, encoding: .utf8)
+        try allCmds.write(to: URL(fileURLWithPath: self.outputFile), atomically: true, encoding: .utf8)
     }
 
     struct Vars {

--- a/Tools/generate-command-models/GenerateCommandModels.swift
+++ b/Tools/generate-command-models/GenerateCommandModels.swift
@@ -176,14 +176,12 @@ struct GenerateCommandModels: AsyncParsableCommand {
 
         private func argSwitchCase(_ arg: ArgumentInfoV0) -> String {
             let flag = arg.kind == .flag
-            var name: String?
-            if let longName = arg.names?.filter { $0.kind == .long }.first?.name {
-                name = "--" + longName
-            } else if let shortName = arg.names?.filter { $0.kind == .short }.first?.name {
-                name = "-" + shortName
-            } else if let longNameWithSingleDash = arg.names?.filter { $0.kind == .longWithSingleDash }.first?.name {
-                name = "-" + longNameWithSingleDash
-            }
+            let name: String? = arg.names?.compactMap { name in
+                switch name.kind {
+                case .long: return "--" + name.name
+                case .short, .longWithSingleDash: return "-" + name.name
+                }
+            }.first
 
             guard let name else { fatalError("Unable to find a suitable argument name for \(arg)") }
 


### PR DESCRIPTION
### Summary

This PR addresses a few compiler warnings and includes a small refactor.

### Changes

- Removed unnecessary `await` expressions where no async operations were occurring, resolving `No 'async' operations occur within 'await' expression` warnings
- Refactored `arg.names` parsing logic to use `compactMap(...).first`, replacing repetitive `filter(...).first` chains and eliminating a warning
- Replaced unused result from `sys.installer(...)` with `_`
- Replaced unused loop variable `key` with `_` in `for (key, value)` loop
