### PR TITLE
Fix shared mutable state problem with install test

### DIFF
--- a/Tests/SwiftlyTests/InstallTests.swift
+++ b/Tests/SwiftlyTests/InstallTests.swift
@@ -320,17 +320,17 @@ import Testing
             try? FileManager.default.removeItem(atPath: pipePath)
         }
 
-        var receivedMessages: [ProgressInfo] = []
         let decoder = JSONDecoder()
-        var installCompleted = false
 
         let readerTask = Task {
-            guard let fileHandle = FileHandle(forReadingAtPath: pipePath) else { return }
+            var receivedMessages: [ProgressInfo] = []
+
+            guard let fileHandle = FileHandle(forReadingAtPath: pipePath) else { throw SwiftlyError(message: "Unable to open file handle at \(pipePath)") }
             defer { fileHandle.closeFile() }
 
             var buffer = Data()
 
-            while !installCompleted {
+            while true {
                 let data = fileHandle.availableData
                 if data.isEmpty {
                     try await Task.sleep(nanoseconds: 100_000_000)
@@ -347,13 +347,14 @@ import Testing
                         if let progress = try? decoder.decode(ProgressInfo.self, from: lineData) {
                             receivedMessages.append(progress)
                             if case .complete = progress {
-                                installCompleted = true
-                                return
+                                return receivedMessages
                             }
                         }
                     }
                 }
             }
+
+            return receivedMessages
         }
 
         let installTask = Task {
@@ -364,10 +365,10 @@ import Testing
             ])
         }
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { try? await readerTask.value }
-            group.addTask { try? await installTask.value }
-        }
+        let readerResult = await readerTask.result
+        try await installTask.value
+
+        let receivedMessages = try readerResult.get()
 
         #expect(!receivedMessages.isEmpty, "Named pipe should receive progress entries")
 


### PR DESCRIPTION
The nightly snapshot toolchain that's run nightly caught a concurrency problem
in one of the InstallTests that verifies that the pipes are working for the progress
files. Rework the tasks in the test so that it no longer has the concurrency problem.