### PR TITLE
Remove swiftly update message from swiftly run command

### DIFF
--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -58,10 +58,8 @@ struct Run: SwiftlyCommand {
     }
 
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
-        let versionUpdateReminder = try await validateSwiftly(ctx)
-        defer {
-            versionUpdateReminder()
-        }
+        try await validateSwiftly(ctx)
+
         var config = try await Config.load(ctx)
 
         // Handle the specific case where help is requested of the run subcommand

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -29,7 +29,7 @@ struct SelfUpdate: SwiftlyCommand {
     }
 
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
-        let _ = try await validateSwiftly(ctx)
+        try await validateSwiftly(ctx)
 
         let swiftlyBin = Swiftly.currentPlatform.swiftlyBinDir(ctx) / "swiftly"
         guard try await fs.exists(atPath: swiftlyBin) else {

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -95,6 +95,7 @@ extension Data {
 }
 
 extension SwiftlyCommand {
+    @discardableResult
     public mutating func validateSwiftly(_ ctx: SwiftlyCoreContext) async throws -> () -> Void {
         for requiredDir in Swiftly.requiredDirectories(ctx) {
             guard try await fs.exists(atPath: requiredDir) else {


### PR DESCRIPTION
The run command can potentially be running any command and there might be
expected output on stderr that a message can corrupt. Remove the message
from this particular subcommand.