### PR TITLE
Fix Zsh auto-completions setup instructions

### DIFF
--- a/Documentation/SwiftlyDocs.docc/shell-autocompletion.md
+++ b/Documentation/SwiftlyDocs.docc/shell-autocompletion.md
@@ -21,7 +21,7 @@ swiftly --generate-completion-script <shell>
         Otherwise, you'll need to add a path for completion scripts to your function path, and turn on completion script autoloading. First, add these lines to ~/.zshrc:
 
         ```
-        fpath=(~/.zsh/completion $fpath)
+        fpath=(~/.zsh/completions $fpath)
         autoload -U compinit
         compinit
         ```
@@ -29,7 +29,7 @@ swiftly --generate-completion-script <shell>
         Next, create the completion directory and add the swiftly completions to it:
 
         ```
-        mkdir -p ~/.zsh/completion && swiftly --generate-completion-script zsh > ~/.zsh/completions/swiftly
+        mkdir -p ~/.zsh/completions && swiftly --generate-completion-script zsh > ~/.zsh/completions/_swiftly
         ```
     }
 


### PR DESCRIPTION
Use the plural form for the "completions" folder to maintain consistent naming.

Prefix the generated Zsh completions file with an underscore; otherwise, it won't match the expected naming convention, and the completions will not work.