### PR TITLE
Add a simple test for any self-update subcommand parse errors

### DIFF
--- a/Tests/SwiftlyTests/SubcommandParsingTests.swift
+++ b/Tests/SwiftlyTests/SubcommandParsingTests.swift
@@ -1,0 +1,12 @@
+import ArgumentParser
+@testable import Swiftly
+import Testing
+
+// Test for simple mistakes declaring options and arguments in subcommands
+// that only show up at runtime. For example, a non-optional type for an
+// @Option will produce an error "Replace with a static variable, or let constant."
+@Suite struct SubcommandParsingTests {
+    @Test func selfUpdateParse() throws {
+        try SelfUpdate.parse([])
+    }
+}


### PR DESCRIPTION
Some mistakes in option and argument declaration only surface at runtime, such as
#414 . Add a test case to verify that trivial parse succeeds on the self-update
subcommand to catch problems in the future.