### PR TITLE
Testing: `withMockedHome`: Forward errors from function under test

### DIFF
--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -336,6 +336,7 @@ public enum SwiftlyTests {
                 if cleanBinDir {
                     try await fs.remove(atPath: Swiftly.currentPlatform.swiftlyBinDir(Self.ctx))
                 }
+                throw error
             }
         }
     }


### PR DESCRIPTION
The `withMockedHome` function was swallowing errors from the function under test. This meant that invocations of Swiftly that should have resulted in a test failure would silently pass. e.g. `swiftly uninstall 1.2.4 4.5.6` as a test case would pass, even though Swiftly was emitting an error.

There were a couple of cases where this behavior was being relied on for the UseTests to verify that switching to a non-existent toolchain version wouldn't change things from the selected version. In those cases, we want to swallow the error.