### PR TITLE
feat: add support for Gentoo Linux in HTTP client and package management

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -18,6 +18,7 @@ public struct Linux: Platform {
         .rhel9,
         .amazonlinux2,
         .debian12,
+        .gentoo,
     ]
 
     public init() {}
@@ -227,6 +228,25 @@ public struct Linux: Platform {
                 "gcc",
                 "libstdc++-12-dev",
             ]
+        case "gentoo":
+            [
+                "dev-vcs/git",
+                "app-arch/unzip",
+                "app-crypt/gnupg",
+                "net-misc/curl",
+                "dev-libs/libxml2",
+                "sys-libs/readline",
+                "dev-db/sqlite",
+                "sys-devel/binutils",
+                "sys-devel/gcc",
+                "sys-libs/glibc",
+                "dev-lang/python",
+                "sys-apps/util-linux",
+                "sys-libs/zlib",
+                "sys-libs/ncurses",
+                "dev-libs/icu",
+                "dev-util/pkgconf",
+            ]
         default:
             []
         }
@@ -250,6 +270,8 @@ public struct Linux: Platform {
             "yum"
         case "debian12":
             "apt-get"
+        case "gentoo":
+            "emerge"
         default:
             nil
         }
@@ -322,6 +344,10 @@ public struct Linux: Platform {
                 return false
             case "yum":
                 try self.runProgram("yum", "list", "installed", package, quiet: true)
+                return true
+            case "emerge":
+                // Use portage's qlist to check if package is installed
+                try self.runProgram("qlist", "-I", package, quiet: true)
                 return true
             default:
                 return true
@@ -586,6 +612,8 @@ public struct Linux: Platform {
             }
 
             return .rhel9
+        } else if id == "gentoo" || (idlike ?? "").contains("gentoo") {
+            return .gentoo
         } else if let pd = [
             PlatformDefinition.ubuntu1804, .ubuntu2004, .ubuntu2204, .ubuntu2404, .debian12, .fedora39,
         ].first(where: { $0.name == id + versionID }) {

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -550,7 +550,7 @@ public struct SwiftlyHTTPClient: Sendable {
         {
         // These are new platforms that aren't yet in the list of known platforms in the OpenAPI schema
         case PlatformDefinition.ubuntu2404.name, PlatformDefinition.debian12.name,
-             PlatformDefinition.fedora39.name:
+             PlatformDefinition.fedora39.name, PlatformDefinition.gentoo.name:
             .init(platform.name)
 
         case PlatformDefinition.ubuntu2204.name:

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -46,6 +46,9 @@ public struct PlatformDefinition: Codable, Equatable, Sendable {
     public static let debian12 = PlatformDefinition(
         name: "debian12", nameFull: "debian12", namePretty: "Debian GNU/Linux 12"
     )
+    public static let gentoo = PlatformDefinition(
+        name: "gentoo", nameFull: "gentoo", namePretty: "Gentoo Linux"
+    )
 }
 
 public struct RunProgramError: Swift.Error {


### PR DESCRIPTION
This pull request adds support for Gentoo Linux as a recognized platform in the codebase. It introduces Gentoo-specific configuration, package lists, and package manager handling, ensuring that Gentoo can be properly detected and managed alongside other Linux distributions.

**Gentoo Linux support:**

* Added `gentoo` to the list of known Linux platforms in `PlatformDefinition` and updated platform detection logic to recognize Gentoo systems. [[1]](diffhunk://#diff-b34b6716eb8e703f78923b67daf2df4ac1d56b5bb35500fca27ed1fe47c2cda0R49-R51) [[2]](diffhunk://#diff-8ad2e133469c216218c352dfe9235fabd7bc76e415aba45a538c12dfc997d0e5R615-R616)
* Included Gentoo in the list of platforms handled by the HTTP client, enabling API compatibility.

**Package management and configuration:**

* Added Gentoo-specific package list and mapped the package manager to `emerge` in the `Linux` platform implementation. [[1]](diffhunk://#diff-8ad2e133469c216218c352dfe9235fabd7bc76e415aba45a538c12dfc997d0e5R21) [[2]](diffhunk://#diff-8ad2e133469c216218c352dfe9235fabd7bc76e415aba45a538c12dfc997d0e5R231-R249) [[3]](diffhunk://#diff-8ad2e133469c216218c352dfe9235fabd7bc76e415aba45a538c12dfc997d0e5R273-R274)
* Implemented package installation checks using Portage's `qlist` for Gentoo.