### PR TITLE
Update message: prefer ASCII arrow

### DIFF
--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -128,7 +128,7 @@ struct Update: SwiftlyCommand {
         )
 
         try await Uninstall.execute(ctx, parameters.oldToolchain, &config, verbose: self.root.verbose)
-        await ctx.message("Successfully updated \(parameters.oldToolchain) ⟶ \(newToolchain)")
+        await ctx.message("Successfully updated \(parameters.oldToolchain) -> \(newToolchain)")
 
         if let postInstallScript {
             guard let postInstallFile = self.postInstallFile else {


### PR DESCRIPTION
A minor detail: I noticed the non-ASCII arrow sticking out while using Swiftly and checked that this is not used elsewhere (see line 113). So fix this for consistency; users who prefer ligatures will of course have their font settings dialed in accordingly and be unaffected.