### PR TITLE
Add zip as a dependency on Linux distributions

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -97,6 +97,7 @@ public struct Linux: Platform {
                 "tzdata",
                 "git",
                 "unzip",
+                "zip",
                 "pkg-config",
             ]
         case "ubuntu2004":
@@ -104,6 +105,7 @@ public struct Linux: Platform {
                 "binutils",
                 "git",
                 "unzip",
+                "zip",
                 "gnupg2",
                 "libc6-dev",
                 "libcurl4-openssl-dev",
@@ -123,6 +125,7 @@ public struct Linux: Platform {
                 "binutils",
                 "git",
                 "unzip",
+                "zip",
                 "gnupg2",
                 "libc6-dev",
                 "libcurl4-openssl-dev",
@@ -143,6 +146,7 @@ public struct Linux: Platform {
                 "binutils",
                 "git",
                 "unzip",
+                "zip",
                 "gnupg2",
                 "libc6-dev",
                 "libcurl4-openssl-dev",
@@ -164,6 +168,7 @@ public struct Linux: Platform {
                 "gcc",
                 "git",
                 "unzip",
+                "zip",
                 "glibc-static",
                 "gzip",
                 "libbsd",
@@ -200,6 +205,7 @@ public struct Linux: Platform {
                 "gcc",
                 "git",
                 "unzip",
+                "zip",
                 "libcurl-devel",
                 "libedit-devel",
                 "libicu-devel",
@@ -226,6 +232,8 @@ public struct Linux: Platform {
                 "git",
                 "gcc",
                 "libstdc++-12-dev",
+                "unzip",
+                "zip",
             ]
         default:
             []


### PR DESCRIPTION
On Linux, Swift Testing uses the zip package/tool to compress directories when they are recorded as test attachments.

Issue: #450