### PR TITLE
Fix `swiftly run -h` to show help message

### DIFF
--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -63,7 +63,7 @@ struct Run: SwiftlyCommand {
         var config = try await Config.load(ctx)
 
         // Handle the specific case where help is requested of the run subcommand
-        if command == ["--help"] {
+        if command == ["--help"] || command == ["-h"] {
             throw CleanExit.helpRequest(self)
         }
 

--- a/Tests/SwiftlyTests/RunTests.swift
+++ b/Tests/SwiftlyTests/RunTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Foundation
 @testable import Swiftly
 @testable import SwiftlyCore
@@ -83,5 +84,24 @@ import Testing
         (command, selector) = try Run.extractProxyArguments(command: ["swift", "build"])
         #expect(["swift", "build"] == command)
         #expect(nil == selector)
+    }
+
+    /// Tests the help functionality of the `run` command
+    @Test(.testHomeMockedToolchain()) func runHelp() async throws {
+        // Test --help is handled correctly
+        do {
+            try await SwiftlyTests.runCommand(Run.self, ["run", "--help"])
+            #expect(false)
+        } catch {
+            #expect(error is CleanExit)
+        }
+
+        // Test -h is handled correctly
+        do {
+            try await SwiftlyTests.runCommand(Run.self, ["run", "-h"])
+            #expect(false)
+        } catch {
+            #expect(error is CleanExit)
+        }
     }
 }


### PR DESCRIPTION
resolve https://github.com/swiftlang/swiftly/issues/447

<details>

<summary>`swiftly run -h` now works correctly</summary>

```sh
% ./.build/debug/swiftly run -h    
OVERVIEW: Run a command while proxying to the selected toolchain commands.

USAGE: swiftly run <command> ...

ARGUMENTS:
  <command>               Run a command while proxying to the selected toolchain commands.

        Run a command with a selected toolchain. The toolchain commands become the default in the system path.

        You can run one of the usual toolchain commands directly:

            $ swiftly run swift build

        Or you can run another program (or script) that runs one or more toolchain commands:

            $ CC=clang swiftly run make  # Builds targets using clang
            $ swiftly run ./build-things.sh  # Script invokes 'swift build' to create certain product binaries

        Toolchain selection is determined by swift version files `.swift-version`, with a default global as the fallback. See the `swiftly use` command for more
        details.

        You can also override the selection mechanisms temporarily for the duration of the command using a special syntax. An argument prefixed with a '+' will
        be treated as the selector.

            $ swiftly run swift build +latest
            $ swiftly run swift build +5.10.1

        The first command builds the swift package with the latest toolchain and the second selects the 5.10.1 toolchain. Note that if these aren't installed
        then run will fail with an error message. You can pre-install the toolchain using `swiftly install <toolchain>` to ensure success.

        If the command that you are running needs the arguments with the '+' prefixes then you can escape it by doubling the '++'.

            $ swiftly run ./myscript.sh ++abcde

        The script will receive the argument as '+abcde'. If there are multiple arguments with the '+' prefix that should be escaped you can disable the
        selection using a '++' argument, which turns off any selector argument processing for subsequent arguments. This is analogous to the '--' that turns off
        flag and option processing for subsequent arguments in many argument parsers.

            $ swiftly run ./myscript.sh ++ +abcde +xyz

        The script will receive the argument '+abcde' followed by '+xyz'.

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.
```

</details>