### PR TITLE
Fix resolution of the xcode selector to the xcode version

### DIFF
--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -299,7 +299,7 @@ struct Install: SwiftlyCommand {
                     category = "development"
                 }
             case .xcode:
-                fatalError("unreachable: xcode toolchain cannot be installed with swiftly")
+                throw SwiftlyError(message: "xcode toolchain is installed with Xcode")
             }
 
             let animation: ProgressReporterProtocol? =


### PR DESCRIPTION
There are places that attempt this resolution independently of an install.  It should be possible to resolve the Xcode selector to the Xcode toolchain in those cases. An actual install using that selector should throw an error instead of a fatalError that aborts the entire process.