### PR TITLE
Ensure `--use` will select the toolchain

### DIFF
--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -254,8 +254,14 @@ struct Install: SwiftlyCommand {
             let installInfo = InstallInfo(
                 version: version, alreadyInstalled: true
             )
+            let pathChanged = if useInstalledToolchain {
+                try await Use.execute(ctx, version, globalDefault: false, verbose: verbose, &config)
+            } else {
+                false
+            }
+
             try await ctx.output(installInfo)
-            return (nil, false)
+            return (nil, pathChanged)
         }
 
         // Ensure the system is set up correctly before downloading it. Problems that prevent installation

--- a/Tests/SwiftlyTests/InstallTests.swift
+++ b/Tests/SwiftlyTests/InstallTests.swift
@@ -264,6 +264,25 @@ import Testing
         try await SwiftlyTests.validateInUse(expected: .newStable)
     }
 
+    /// Verify that the pre-installed toolchain will be marked as in-use if the --use flag is specified.
+    @Test(.mockedSwiftlyVersion(), .testHomeMockedToolchain()) func installUseFlagOnAlreadyInstalledToolchain() async throws {
+        // GIVEN we install an old toolchain
+        try await SwiftlyTests.installMockedToolchain(toolchain: .oldStable)
+        // AND we use the toolchain
+        try await SwiftlyTests.runCommand(Use.self, ["use", ToolchainVersion.oldStable.name])
+        // THEN the old toolchain should be in use/selected
+        try await SwiftlyTests.validateInUse(expected: .oldStable)
+        // GIVEN a new toolchain is installled without `--use`
+        try await SwiftlyTests.installMockedToolchain(selector: ToolchainVersion.newStable.name)
+        // THEN the old toolchain is in use/selected
+        try await SwiftlyTests.validateInUse(expected: .oldStable)
+
+        // AND GIVEN we installing the new toolchain again with `-use`
+        try await SwiftlyTests.installMockedToolchain(selector: ToolchainVersion.newStable.name, args: ["--use"])
+        // THEN the new toolchain should be in use/selected
+        try await SwiftlyTests.validateInUse(expected: .newStable)
+    }
+
     /// Verify that xcode can't be installed like regular toolchains
     @Test(.testHomeMockedToolchain()) func installXcode() async throws {
         try await #expect(throws: SwiftlyError.self) {


### PR DESCRIPTION
If a toolchain was already installed when running `swiftly install --use`, said toolchain was not being set to be used as a different code path was followed.

Update the code path to set the toolchain when `--use` is selected even if the toolchain is already installed.