### PR TITLE
Skip `tests-selfhosted-macos` jobs on forked repositories

### DIFF
--- a/.github/workflows/62_snapshot_check.yml
+++ b/.github/workflows/62_snapshot_check.yml
@@ -30,6 +30,7 @@ jobs:
   tests-selfhosted-macos:
     name: Test (Smoke Test - Nightly Swift Toolchain) / macOS Sequoia ARM64
     runs-on: [self-hosted, macos, sequoia, ARM64]
+    if: ${{ github.repository == 'swiftlang/swiftly' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly_snapshot_check.yml
+++ b/.github/workflows/nightly_snapshot_check.yml
@@ -30,6 +30,7 @@ jobs:
   tests-selfhosted-macos:
     name: Test (Smoke Test - Nightly Swift Toolchain) / macOS Sequoia ARM64
     runs-on: [self-hosted, macos, sequoia, ARM64]
+    if: ${{ github.repository == 'swiftlang/swiftly' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The `tests-selfhosted-macos` jobs run periodically on self-hosted runners, but forked repositories cannot access self-hosted runners. As a result, failure notifications like the one below are sent daily via email, which is very annoying.

<img height="400" alt="IMG_0820" src="https://github.com/user-attachments/assets/d72cca88-7771-4fcb-a9f1-c1f23ad38fc4" />

To prevent that, I modified the `tests-selfhosted-macos` jobs so that they do not run in forked repositories.