### PR TITLE
Fix nightly smoke test failure

### DIFF
--- a/Tests/SwiftlyTests/CommandLineTests.swift
+++ b/Tests/SwiftlyTests/CommandLineTests.swift
@@ -270,8 +270,9 @@ public struct CommandLineTests {
     func testSwift() async throws {
         let tmp = fs.mktemp()
         try await fs.mkdir(atPath: tmp)
-        try await sys.swift().package()._init(.package_path(tmp), .type("executable")).run()
-        try await sys.swift().build(.package_path(tmp), .configuration("release")).run()
+        let swiftExec: Executable = .path(try Executable.name("swift").resolveExecutablePath(in: .inherit))
+        try await sys.swift(executable: swiftExec).package()._init(.package_path(tmp), .type("executable")).run()
+        try await sys.swift(executable: swiftExec).build(.package_path(tmp), .configuration("release")).run()
     }
 
     @Test func testMake() async throws {


### PR DESCRIPTION
There is some variability to the path where executables get resolved in the current
version of subprocess. This test appears to trip on it as the SwiftPM that generated
the package sets the swift tools version to something newer than what the subsequent
build command uses, causing it to fail.