### PR TITLE
Skip macOS CI jobs on forked repositories

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,7 @@ jobs:
   macos-tests-selfhosted:
     name: Test (Self Hosted) / macOS Sequoia ARM64
     runs-on: [self-hosted, macos, sequoia, ARM64]
+    if: ${{ github.repository == 'swiftlang/swiftly' }}
     strategy:
       fail-fast: false
     steps:
@@ -85,6 +86,7 @@ jobs:
   releasebuildcheckmacos:
     name: Release Build Check / macOS
     runs-on: [self-hosted, macos, sequoia, ARM64]
+    if: ${{ github.repository == 'swiftlang/swiftly' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Those macOS jobs are triggered when syncing the main branch or released branches with the upstream repo, but forked repos cannot access self-hosted macOS runners, so it is always canceled after one day has passed.

To avoid such unnecessary waiting time, I modified those jobs to be skipped on forked repositories.