### PR TITLE
Fix two minor typos (#474)

### DIFF
--- a/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/uninstall-toolchains.md
@@ -11,7 +11,7 @@ If you have a released version that you want to uninstall then give the exact th
 $ swiftly uninstall 5.6.1
 ```
 
-When you're done working with every patch of a minor swift release you can remove them all by omitting the patch version.
+When you're done working with every patch of a minor Swift release you can remove them all by omitting the patch version.
 
 ```
 $ swiftly uninstall 5.6

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -263,7 +263,7 @@ public struct Linux: Platform {
                         \(manager) -y install gpg
                     """
                 } else {
-                    msg += "you can install gpg to get signature verifications of the toolchahins."
+                    msg += "you can install gpg to get signature verifications of the toolchains."
                 }
                 msg += "\n" + Self.skipVerificationMessage
 


### PR DESCRIPTION
* Fix typo in gpg installation message
* Fix capitalization of 'Swift' in uninstall docs