### PR TITLE
Ensure the macOS SDK exists at install time

### DIFF
--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -62,10 +62,11 @@ public struct MacOS: Platform {
         // shell script for installing developer tools on macOS.
         if !result.terminationStatus.isSuccess {
             await ctx.print("""
-            \nWARNING: Could not find a macOS SDK on the system. A macOS SDK is required for the toolchain to work correctly. Please install one via Xcode (https://developer.apple.com/xcode) or run the following command on your machine to install the Command Line Tools for Xcode:\n`xcode-select --install`.
+            \nWARNING: Could not find a macOS SDK on the system. A macOS SDK is required for the toolchain to work correctly. Please install one via Xcode (https://developer.apple.com/xcode) or run the following command on your machine to install the Command Line Tools for Xcode:
+            xcode-select --install
 
             More information on installing the Command Line Tools can be found here: https://developer.apple.com/documentation/xcode/installing-the-command-line-tools/#Install-the-Command-Line-Tools-package-in-Terminal. If developer tools are located at a non-default location on disk, use the following command to specify the Xcode that you wish to use for Command Line Tools for Xcode:
-            `sudo xcode-select --switch path/to/Xcode.app`\n
+            sudo xcode-select --switch path/to/Xcode.app\n
             """)
         }
 


### PR DESCRIPTION
* Ensure a macOS SDK is installed when verifying system prerequisites, if it is not installed. Warn the user at install time

The warning that the end-user will receive is the following (currently):
> WARNING: Could not find a macOS SDK on the system. A macOS SDK is required for the toolchain to work correctly. Please install one via Xcode (https://developer.apple.com/xcode) or run the following command on your machine to install the command line developer tools: `xcode-select --install`.

>If developer tools are located at a non-default location on disk, use `sudo xcode-select --switch path/to/Xcode.app` to     specify the Xcode that you wish to use for command line developer tools.