### PR TITLE
Don't install the SL SDK into the user account

### DIFF
--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -277,7 +277,7 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 
         _ = FileManager.default.changeCurrentDirectoryPath(cwd.string)
 
-        try await sys.swift().build(.swift_sdks_path(sdkDir.string), .swift_sdk("swift-\(swiftVersion)-RELEASE_static-linux-0.0.1"), .arch(arch), .product("swiftly"), .pkg_config_path(pkgConfigPath / "lib/pkgconfig"), .configuration("release")).runEcho()
+        try await sys.swift().build(.swift_sdks_path(sdkDir.string), .swift_sdk("\(arch)-swift-linux-musl"), .arch(arch), .product("swiftly"), .pkg_config_path(pkgConfigPath / "lib/pkgconfig"), .configuration("release")).runEcho()
 
         let releaseDir = cwd / ".build/release"
 
@@ -297,7 +297,7 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 
             let testArchive = debugDir / "test-swiftly-linux-\(arch).tar.gz"
 
-            try await sys.swift().build(.swift_sdks_path(sdkDir.string), .swift_sdk("swift-\(swiftVersion)-RELEASE_static-linux-0.0.1"), .arch(arch), .product("test-swiftly"), .pkg_config_path(pkgConfigPath / "lib/pkgconfig"), .configuration("release")).runEcho()
+            try await sys.swift().build(.swift_sdks_path(sdkDir.string), .swift_sdk("\(arch)-swift-linux-musl"), .arch(arch), .product("test-swiftly"), .pkg_config_path(pkgConfigPath / "lib/pkgconfig"), .configuration("debug")).runEcho()
             try await sys.tar(.directory(debugDir)).create(.compressed, .archive(testArchive), files: ["test-swiftly"]).runEcho()
 
             print(testArchive)


### PR DESCRIPTION
When building the release binary for swiftly it uses the static linux SDK with musl to create a system independent binary. The SDK was being installed by the build-swiftly-release tool into the user's home directory with "swift sdk install" command and it tries to uninstall it afterwards. This can pollute a user's system or remove the SDK if they installed it already.

In this approach the SDK is extracted into a scratch directory and that directory is provided to the "swift build" command so that it can find it there.