### PR TITLE
Prepend SWIFTLY_BIN_DIR to the PATH

### DIFF
--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -113,7 +113,9 @@ struct Init: SwiftlyCommand {
             set -x SWIFTLY_TOOLCHAINS_DIR "\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
 
             # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
-            set -e PATH[(contains -i "$SWIFTLY_BIN_DIR" $PATH)]
+            while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)
+                set -e PATH[$index]
+            end
             set -x PATH "$SWIFTLY_BIN_DIR" $PATH
 
             """


### PR DESCRIPTION
Instead of checking for the presence of the bin directory in the PATH swiftly should prepend it. This will help to ensure that the proxies aren't shadowed by other tools earlier in the PATH.

Closes #484