### PR TITLE
Bump subprocess to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f95cf109954483e637b3157eb63792ab8362707f4fb93c0e30ff5ad7638fc82d",
+  "originHash" : "8d862702b4248c3d083113634780649da3f9befc302a22151dd1923de27cd91f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-subprocess",
       "state" : {
-        "revision" : "44922dfe46380cd354ca4b0208e717a3e92b13dd",
-        "version" : "0.2.1"
+        "revision" : "ba5888ad7758cbcbe7abebac37860b1652af2d9c",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.7.2"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.2"),
         .package(url: "https://github.com/apple/swift-system", from: "1.4.2"),
-        .package(url: "https://github.com/swiftlang/swift-subprocess", exact: "0.2.1", traits: []),
+        .package(url: "https://github.com/swiftlang/swift-subprocess", exact: "0.3.0", traits: []),
         // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Package.swift Plugins/ Sources/ Tests/`
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.49.18"),
     ],


### PR DESCRIPTION
Bump subprocess to version 0.3.0 so that it no longer picks
an executable with the same name in the PATH at random.
See [swift-subprocess#210](https://github.com/swiftlang/swift-subprocess/issues/210)

Closes #463