### PR TITLE
Include toolchain location in `swiftly list --format json`

### DIFF
--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -55,11 +55,16 @@ struct List: SwiftlyCommand {
         let toolchains = config.listInstalledToolchains(selector: selector).sorted { $0 > $1 }
         let (inUse, _) = try await selectToolchain(ctx, config: &config)
 
-        let installedToolchainInfos = toolchains.compactMap { toolchain -> InstallToolchainInfo? in
-            InstallToolchainInfo(
-                version: toolchain,
-                inUse: inUse == toolchain,
-                isDefault: toolchain == config.inUse
+        var installedToolchainInfos: [InstallToolchainInfo] = []
+        for toolchain in toolchains {
+            let location = "\(try await Swiftly.currentPlatform.findToolchainLocation(ctx, toolchain))"
+            installedToolchainInfos.append(
+                InstallToolchainInfo(
+                    version: toolchain,
+                    inUse: inUse == toolchain,
+                    isDefault: toolchain == config.inUse,
+                    location: location
+                )
             )
         }
 

--- a/Sources/Swiftly/OutputSchema.swift
+++ b/Sources/Swiftly/OutputSchema.swift
@@ -182,11 +182,13 @@ struct InstallToolchainInfo: OutputData {
     let version: ToolchainVersion
     let inUse: Bool
     let isDefault: Bool
+    let location: String
 
-    init(version: ToolchainVersion, inUse: Bool, isDefault: Bool) {
+    init(version: ToolchainVersion, inUse: Bool, isDefault: Bool, location: String) {
         self.version = version
         self.inUse = inUse
         self.isDefault = isDefault
+        self.location = location
     }
 
     var description: String {
@@ -205,12 +207,14 @@ struct InstallToolchainInfo: OutputData {
         case version
         case inUse
         case isDefault
+        case location
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.inUse, forKey: .inUse)
         try container.encode(self.isDefault, forKey: .isDefault)
+        try container.encode(self.location, forKey: .location)
 
         // Encode the version as a object
         var versionContainer = container.nestedContainer(
@@ -244,6 +248,7 @@ struct InstallToolchainInfo: OutputData {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.inUse = try container.decode(Bool.self, forKey: .inUse)
         self.isDefault = try container.decode(Bool.self, forKey: .isDefault)
+        self.location = try container.decode(String.self, forKey: .location)
 
         // Decode the version as a object
         let versionContainer = try container.nestedContainer(

--- a/Tests/SwiftlyTests/ListTests.swift
+++ b/Tests/SwiftlyTests/ListTests.swift
@@ -285,4 +285,21 @@ import Testing
             #expect(inUseToolchain.isDefault == true)
         }
     }
+
+    @Test func listJsonFormatIncludesLocation() async throws {
+        try await self.runListTest {
+            let output = try await SwiftlyTests.runWithMockedIO(
+                List.self, ["list", "--format", "json"], format: .json
+            )
+
+            let listInfo = try JSONDecoder().decode(
+                InstalledToolchainsListInfo.self,
+                from: output[0].data(using: .utf8)!
+            )
+
+            for toolchain in listInfo.toolchains {
+                #expect(toolchain.location.isEmpty == false)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Include the location in disk of each downloaded toolchain when running `swiftly list --format json`.

This will help fix an open issue in vscode-swfit where toolchains from swiftly show up twice in the toolchain selection quick pick (one list found when looking on disk, and the other produced by `swiftly list`. (https://github.com/swiftlang/vscode-swift/issues/1850)

Issue: #501