### PR TITLE
Swiftly deletes itself when installed on Linux with Homebrew

### DIFF
--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -269,12 +269,12 @@ extension Platform {
         if try await fs.isSymLink(atPath: path) {
             return true
         }
-        #if os(Linux)
+#if os(Linux)
         if path.string.contains(".linuxbrew/Cellar/") {
             // Linuxbrew installation like /home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1/bin/swiftly
             return true
         }
-        #endif
+#endif
         if path.starts(with: fs.home) {
             // In user's home directory, so not system managed.
             return false


### PR DESCRIPTION
Installing swiftly on Linux with Homebrew puts it at `/home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1/bin/swiftly`, which fails the check for [`isSystemManaged`](https://github.com/swiftlang/swiftly/blob/98692bf715de4011cc968886f96056f75cf920bb/Sources/SwiftlyCore/Platform.swift#L267C1-L268C1). Which means that running `swiftly init` will delete itself.

See the following reproduction:

```console
$ brew install swiftly

==> Installing swiftly
==> Pouring swiftly--1.1.1.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1: 10 files, 139.7MB
==> Running `brew cleanup swiftly`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d

$ which swiftly
/home/linuxbrew/.linuxbrew/bin/swiftly

$ ls -la /home/linuxbrew/.linuxbrew/bin/swiftly
lrwxrwxrwx 1 marcprux marcprux 35 Feb  5 09:17 /home/linuxbrew/.linuxbrew/bin/swiftly -> ../Cellar/swiftly/1.1.1/bin/swiftly

$ tree /home/linuxbrew/.linuxbrew/Cellar/swiftly
/home/linuxbrew/.linuxbrew/Cellar/swiftly
└── 1.1.1
    ├── bin
    │   └── swiftly
    ├── etc
    │   └── bash_completion.d
    │       └── swiftly
    ├── INSTALL_RECEIPT.json
    ├── LICENSE.txt
    ├── NOTICE.txt
    ├── README.md
    ├── sbom.spdx.json
    └── share
        ├── fish
        │   └── vendor_completions.d
        │       └── swiftly.fish
        └── zsh
            └── site-functions
                └── _swiftly

10 directories, 9 files

$ /home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1/bin/swiftly init --assume-yes --no-modify-profile --skip-install
Installing swiftly in /home/marcprux/.local/share/swiftly/bin/swiftly...

$ /home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1/bin/swiftly init --assume-yes --no-modify-profile --skip-install
-bash: /home/linuxbrew/.linuxbrew/Cellar/swiftly/1.1.1/bin/swiftly: No such file or directory

$ tree /home/linuxbrew/.linuxbrew/Cellar/swiftly
/home/linuxbrew/.linuxbrew/Cellar/swiftly
└── 1.1.1
    ├── bin
    ├── etc
    │   └── bash_completion.d
    │       └── swiftly
    ├── INSTALL_RECEIPT.json
    ├── LICENSE.txt
    ├── NOTICE.txt
    ├── README.md
    ├── sbom.spdx.json
    └── share
        ├── fish
        │   └── vendor_completions.d
        │       └── swiftly.fish
        └── zsh
            └── site-functions
                └── _swiftly

10 directories, 8 files
```

This PR adds a check for whether the binary is in some path containing ".linuxbrew/Cellar/", which should be general enough to cover most Homebrew Linux configurations.