### PR TITLE
Add support for Nushell and Murex

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For more detailed usage guides there is [documentation](https://swiftpackageinde
 
 ## Platform support
 
-swiftly is supported on Linux and macOS. For more detailed information about swiftly's intended features and implementation, check out the [design document](DESIGN.md).
+swiftly is supported on Linux and macOS, and can automatically configure shell profiles for Bash, Z shell, Fish, Murex, and Nushell. For more detailed information about swiftly's intended features and implementation, check out the [design document](DESIGN.md).
 
 ## Updating swiftly
 
@@ -70,9 +70,9 @@ NOTE: This will not uninstall any toolchains you have installed unless you do so
 
 1. (Optional) Remove all installed toolchains with `swiftly uninstall all`.
 
-2. Remove the swiftly home and bin directories. The default location might be `~/.swiftpm` or `.local/share/swiftly`. You can refer to the environment variables `SWIFTLY_HOME_DIR` and `SWIFTLY_BIN_DIR` in your associated profile file (`.zprofile`, `.bash_profile`, `.profile`, or `fish/conf.d`).
+2. Remove the swiftly home and bin directories. The default location might be `~/.swiftpm` or `.local/share/swiftly`. You can refer to the environment variables `SWIFTLY_HOME_DIR` and `SWIFTLY_BIN_DIR` in your associated profile file (`.zprofile`, `.bash_profile`, `.murex_profile`, `.profile`, `fish/conf.d` or `nushell/autoload`).
 
-3. Remove any sections added by swiftly in your `.zprofile`, `.bash_profile`, `.profile`, or `fish/conf.d` files. These sections might look like this:
+3. Remove any sections swiftly added to your aforementioned profile file. These sections might look like this:
 
    ```sh
    # Added by swiftly
@@ -100,9 +100,9 @@ Swiftly prior to verion 1.0.0 had a different installation and delivery mechanis
 1. Uninstall older swiftly
 2. Install the newest swiftly using the instructions above
 
-To uninstall the old swiftly, first locate the swiftly home directory, which is often in `~/.local/share/swiftly` and remove it. Then check your shell profile files (`~/.profile`, `~/.zprofile`, `~/.bash_profile`, or `~/.config/fish/conf.d`) and remove any entries that attempt to source the `env.sh` or `env.fish` file in the swiftly home directory. Finally, remove the symbolic links that swiftly placed in your `~/.local/bin` to toolchain binaries (e.g. swift, clang, lldb, etc.). These will likely be symbolic links to toolchain directories in the swiftly home directory. Remove them so that there aren't any orphaned path entries.
+To uninstall the old swiftly, first locate the swiftly home directory, which is often in `~/.local/share/swiftly` and remove it. Then check your shell profile files (`~/.profile`, `~/.zprofile`, `~/.bash_profile`, or `~/.config/fish/conf.d`) and remove any entries that attempt to source the `env.sh` or `env.fish` file in the swiftly home directory. Finally, remove the symbolic links that swiftly placed in your `~/.local/bin` to toolchain binaries (e.g. `swift`, `clang`, `lldb`, etc.). These will likely be symbolic links to toolchain directories in the swiftly home directory. Remove them so that there aren't any orphaned path entries.
 
-Restart your shell and/or terminal to get a fresh environment. You should be ready to installing the new swiftly.
+Restart your shell and/or terminal to get a fresh environment. You should be ready to install the new swiftly.
 
 ## FAQ
 

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -407,7 +407,7 @@ struct Init: SwiftlyCommand {
             await ctx.message("""
             To begin using installed swiftly from your current shell, first run the following command:
             
-                $ \(sourceLine.components(separatedBy: .newlines).last!)
+                \(sourceLine.components(separatedBy: .newlines).last!)
 
             """)
         }

--- a/Sources/Swiftly/Link.swift
+++ b/Sources/Swiftly/Link.swift
@@ -46,8 +46,25 @@ struct Link: SwiftlyCommand {
             await ctx.message("""
             Linked swiftly to Swift \(toolchainVersion.name).
 
-            \(Messages.refreshShell)
             """)
+            
+            let shell =
+                if let s = ProcessInfo.processInfo.environment["SHELL"] {
+                    s
+                } else {
+                    try await Swiftly.currentPlatform.getShell()
+                }
+
+            // Fish and Nushell don't cache executable paths, so the refresh instruction is not applicable.
+            if !shell.hasSuffix("nu") && !shell.hasSuffix("fish") {
+                let refreshCommand =
+                    if shell.hasSuffix("murex") {
+                        "murex-update-exe-list"
+                    } else {
+                        "hash -r"
+                    }
+                await ctx.message(Messages.refreshShell(refreshCommand))
+            }
         } else {
             await ctx.message("""
             Swiftly is already linked to Swift \(toolchainVersion.name).

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -137,25 +137,21 @@ extension SwiftlyCommand {
 
     public static func handlePathChange(_ ctx: SwiftlyCoreContext) async throws {
         let shell =
-            if let s = ProcessInfo.processInfo.environment["SHELL"]
-        {
-            s
-        } else {
-            try await Swiftly.currentPlatform.getShell()
-        }
+            if let s = ProcessInfo.processInfo.environment["SHELL"] {
+                s
+            } else {
+                try await Swiftly.currentPlatform.getShell()
+            }
 
-        // Fish doesn't cache its path, so this instruction is not necessary.
-        if !shell.hasSuffix("fish") {
-            await ctx.message(
-                """
-                NOTE: Swiftly has updated some elements in your path and your shell may not yet be
-                aware of the changes. You can update your shell's environment by running
-
-                hash -r
-
-                or restarting your shell.
-
-                """)
+        // Fish and Nushell don't cache executable paths, so this instruction is not necessary.
+        if !shell.hasSuffix("fish") && !shell.hasSuffix("nu") {
+            let refreshCommand =
+                if shell.hasSuffix("murex") {
+                    "murex-update-exe-list"
+                } else {
+                    "hash -r"
+                }
+            await ctx.message(Messages.refreshShell(refreshCommand))
         }
     }
 }

--- a/Sources/Swiftly/Unlink.swift
+++ b/Sources/Swiftly/Unlink.swift
@@ -45,7 +45,24 @@ struct Unlink: SwiftlyCommand {
 
         if pathChanged {
             await ctx.message(Messages.unlinkSuccess)
-            await ctx.message(Messages.refreshShell)
+
+            let shell =
+                if let s = ProcessInfo.processInfo.environment["SHELL"] {
+                    s
+                } else {
+                    try await Swiftly.currentPlatform.getShell()
+                }
+
+            // Fish and Nushell don't cache executable paths, so the refresh instruction is not applicable.
+            if !shell.hasSuffix("nu") && !shell.hasSuffix("fish") {
+                let refreshCommand =
+                    if shell.hasSuffix("murex") {
+                        "murex-update-exe-list"
+                    } else {
+                        "hash -r"
+                    }
+                await ctx.message(Messages.refreshShell(refreshCommand))
+            }
         }
     }
 

--- a/Sources/Swiftly/Update.swift
+++ b/Sources/Swiftly/Update.swift
@@ -146,7 +146,23 @@ struct Update: SwiftlyCommand {
         }
 
         if pathChanged {
-            await ctx.message(Messages.refreshShell)
+            let shell =
+                if let s = ProcessInfo.processInfo.environment["SHELL"] {
+                    s
+                } else {
+                    try await Swiftly.currentPlatform.getShell()
+                }
+
+            // Fish and Nushell don't cache executable paths, so the refresh instruction is not applicable.
+            if !shell.hasSuffix("nu") && !shell.hasSuffix("fish") {
+                let refreshCommand =
+                    if shell.hasSuffix("murex") {
+                        "murex-update-exe-list"
+                    } else {
+                        "hash -r"
+                    }
+                await ctx.message(Messages.refreshShell(refreshCommand))
+            }
         }
     }
 

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -1,14 +1,4 @@
 public enum Messages {
-    public static let refreshShell = """
-    NOTE: Swiftly has updated some elements in your path and your shell may not yet be
-    aware of the changes. You can update your shell's environment by running
-
-    hash -r
-
-    or restarting your shell.
-
-    """
-
     public static let unlinkSuccess = """
     Swiftly is now unlinked and will not manage the active toolchain until the following
     command is run:
@@ -33,7 +23,19 @@ public enum Messages {
         You can run the following script as the system administrator (e.g. root) to prepare
         your system:
 
-            \(command)
+            $ \(command)
+
+        """
+    }
+
+    public static func refreshShell(_ command: String) -> String {
+        """
+        NOTE: Swiftly has updated some elements in your PATH and your shell may not yet be
+        aware of the changes. You can update your shell's environment by running
+
+            $ \(command)
+
+        or restarting your shell.
 
         """
     }

--- a/Sources/SwiftlyCore/Messages.swift
+++ b/Sources/SwiftlyCore/Messages.swift
@@ -3,7 +3,7 @@ public enum Messages {
     Swiftly is now unlinked and will not manage the active toolchain until the following
     command is run:
 
-        $ swiftly link
+        swiftly link
 
 
     """
@@ -12,7 +12,7 @@ public enum Messages {
     Swiftly is currently unlinked and will not manage the active toolchain. You can run
     the following command to link swiftly to the active toolchain:
 
-        $ swiftly link
+        swiftly link
 
 
     """
@@ -23,7 +23,7 @@ public enum Messages {
         You can run the following script as the system administrator (e.g. root) to prepare
         your system:
 
-            $ \(command)
+            \(command)
 
         """
     }
@@ -33,7 +33,7 @@ public enum Messages {
         NOTE: Swiftly has updated some elements in your PATH and your shell may not yet be
         aware of the changes. You can update your shell's environment by running
 
-            $ \(command)
+            \(command)
 
         or restarting your shell.
 

--- a/Sources/TestSwiftly/TestSwiftly.swift
+++ b/Sources/TestSwiftly/TestSwiftly.swift
@@ -140,7 +140,7 @@ struct TestSwiftly: AsyncParsableCommand {
                 env = env.updating(["BASH_ENV": (fs.home / ".profile").string])
             } else if shell.ends(with: "zsh") {
                 env = env.updating(["ZDOTDIR": fs.home.string])
-            } else if shell.ends(with: "fish") {
+            } else if shell.ends(with: "fish") || shell.ends(with: "nu") {
                 env = env.updating(["XDG_CONFIG_HOME": (fs.home / ".config").string])
             }
 
@@ -210,13 +210,21 @@ struct TestSwiftly: AsyncParsableCommand {
         }
 
         // Check that env files are removed
-        let envSh = customLoc / "env.sh"
+        let envSh   = customLoc / "env.sh"
         let envFish = customLoc / "env.fish"
+        let envNu   = customLoc / "env.nu"
+        let envMx   = customLoc / "env.mx"
         guard !(try await fs.exists(atPath: envSh)) else {
             throw TestError("env.sh still exists at \(envSh)")
         }
         guard !(try await fs.exists(atPath: envFish)) else {
             throw TestError("env.fish still exists at \(envFish)")
+        }
+        guard !(try await fs.exists(atPath: envNu)) else {
+            throw TestError("env.nu still exists at \(envNu)")
+        }
+        guard !(try await fs.exists(atPath: envMx)) else {
+            throw TestError("env.mx still exists at \(envMx)")
         }
 
         // Check that config is removed
@@ -241,13 +249,21 @@ struct TestSwiftly: AsyncParsableCommand {
         }
 
         // Check that env files are removed
-        let envSh = swiftlyHome / "env.sh"
+        let envSh   = swiftlyHome / "env.sh"
         let envFish = swiftlyHome / "env.fish"
+        let envNu   = swiftlyHome / "env.nu"
+        let envMx   = swiftlyHome / "env.mx"
         guard !(try await fs.exists(atPath: envSh)) else {
             throw TestError("env.sh still exists at \(envSh)")
         }
         guard !(try await fs.exists(atPath: envFish)) else {
             throw TestError("env.fish still exists at \(envFish)")
+        }
+        guard !(try await fs.exists(atPath: envNu)) else {
+            throw TestError("env.nu still exists at \(envNu)")
+        }
+        guard !(try await fs.exists(atPath: envNu)) else {
+            throw TestError("env.mx still exists at \(envMx)")
         }
 
         // Check that config is removed
@@ -277,12 +293,17 @@ struct TestSwiftly: AsyncParsableCommand {
             fs.home / ".zprofile",
             fs.home / ".bash_profile",
             fs.home / ".bash_login",
+            fs.home / ".murex_profile",
             fs.home / ".profile",
             fs.home / ".config/fish/conf.d/swiftly.fish",
+            fs.home / ".config/nushell/autoload/swiftly.nu",
+            fs.home / "Library/Application Support/nushell/autoload/swiftly.nu",
         ]
 
-        let swiftlySourcePattern = ". \".*\\.swiftly/env\\.sh\""
+        let shSourcePattern = ". \".*\\.swiftly/env\\.sh\""
         let fishSourcePattern = "source \".*\\.swiftly/env\\.fish\""
+        let nuSourcePattern = "source \".*\\.swiftly/env\\.nu\""
+        let murexSourcePattern = "source \".*\\.swiftly/env\\.mx\""
         let commentPattern = "# Added by swiftly"
 
         for profilePath in profilePaths {
@@ -291,8 +312,10 @@ struct TestSwiftly: AsyncParsableCommand {
             let contents = try String(contentsOf: profilePath, encoding: .utf8)
 
             // Check that swiftly-related lines are removed
-            if contents.range(of: swiftlySourcePattern, options: .regularExpression) != nil ||
+            if contents.range(of: shSourcePattern, options: .regularExpression) != nil ||
                 contents.range(of: fishSourcePattern, options: .regularExpression) != nil ||
+                contents.range(of: nuSourcePattern, options: .regularExpression) != nil ||
+                contents.range(of: murexSourcePattern, options: .regularExpression) != nil ||
                 contents.contains(commentPattern)
             {
                 throw TestError("Swiftly references still found in profile file: \(profilePath)")


### PR DESCRIPTION
This patch adds support for automatically configuring Nushell and Murex shell profiles in addition to the current support for Bash/Zsh/Fish (and makes the README list all these under "Platform support").

Also, during `init` the user is now told which shell profile file is getting added to, and during `self-uninstall` Fish users are no longer left with an empty `swiftly.fish` file (it's deleted if the user didn't add anything to it).

I have manually tested initializing, using, and uninstalling this version of swiftly under both new shells on both MacOS and Linux. I haven't ran the automated tests. Nushell and Murex binaries would have to be added to the test runner.

Obsoletes https://github.com/swiftlang/swiftly/pull/284.