### PR TITLE
Simplify `env.fish`

### DIFF
--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -114,10 +114,7 @@ struct Init: SwiftlyCommand {
             set -x SWIFTLY_TOOLCHAINS_DIR "\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
 
             # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
-            while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)
-                set -e PATH[$index]
-            end
-            set -x PATH "$SWIFTLY_BIN_DIR" $PATH
+            fish_add_path -mP "$SWIFTLY_BIN_DIR"
 
             """
         }

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -114,7 +114,8 @@ struct Init: SwiftlyCommand {
             set -x SWIFTLY_TOOLCHAINS_DIR "\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
 
             # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
-            fish_add_path -mP "$SWIFTLY_BIN_DIR"
+            set -gx PATH (string match -v -- "$SWIFTLY_BIN_DIR" $PATH)
+            fish_add_path -P "$SWIFTLY_BIN_DIR"
 
             """
         }


### PR DESCRIPTION
## Summary

The current `env.fish` feels a bit complicated. I refactored it with fish's built-in commands.

The `fish_add_path` options I used:

- ~~`-m`: Move already-included directories to the place they would be added - by default they would be left in place and not added again.~~
- `-p` (default): Add directories to the front of the variable (this is the default).
- `-P`: Manipulate [`$PATH`](https://fishshell.com/docs/current/language.html#envvar-PATH) directly.

refs: https://fishshell.com/docs/current/cmds/fish_add_path.html

## Test

I tested the generated `env.fish` locally with several `PATH` configurations, including cases where `SWIFTLY_BIN_DIR` is absent, already at the beginning, in the middle, or appears multiple times. I didn't commit this test since it's too platform-dependent and requires that all shells are installed.

```swift
    @Test(
        .testHome(),
        arguments: ["/bin/bash", "/bin/zsh", "/bin/fish"],
        [
            (
                path: ["/foo", "/bar"],
                expectedPath: ["/swiftly/bin", "/foo", "/bar"]
            ),
            (
                path: ["/swiftly/bin", "/foo", "/bar"],
                expectedPath: ["/swiftly/bin", "/foo", "/bar"]
            ),
            (
                path: ["/foo", "/swiftly/bin", "/bar"],
                expectedPath: ["/swiftly/bin", "/foo", "/bar"]
            ),
            (
                path: ["/foo", "/swiftly/bin", "/bar", "/swiftly/bin"],
                expectedPath: ["/swiftly/bin", "/foo", "/bar"]
            ),
        ]
    )
    func envPrependsSwiftlyBinDirAndRemovesDuplicates(
        shell: String,
        pathCase: (path: [String], expectedPath: [String])
    ) async throws {
        // GIVEN: a fresh user account without swiftly installed
        try? await fs.remove(atPath: Swiftly.currentPlatform.swiftlyConfigFile(SwiftlyTests.ctx))

        // AND: the user is using the bash shell
        var ctx = SwiftlyTests.ctx
        ctx.mockedShell = shell

        try await SwiftlyTests.$ctx.withValue(ctx) {
            let envScript: FilePath?
            if shell.hasSuffix("bash") || shell.hasSuffix("zsh") {
                envScript = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx) / "env.sh"
            } else if shell.hasSuffix("fish") {
                envScript = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx) / "env.fish"
            } else {
                envScript = nil
            }

            if let envScript {
                #expect(!(try await fs.exists(atPath: envScript)))
            }

            // WHEN: swiftly is invoked to init the user account and finish swiftly installation
            try await SwiftlyTests.runCommand(Init.self, ["init", "--assume-yes", "--skip-install"])

            // THEN: env script modifies $PATH correctly
            let swiftlyHomeDir = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx)
            let swiftlyBinDir = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx)

            func replaceSwiftlyBinDir(in path: [String]) -> [String] {
                path.map { $0 == "/swiftly/bin" ? swiftlyBinDir.string : $0 }
            }

            let inputPath = replaceSwiftlyBinDir(in: pathCase.path)
            let expectedPath = replaceSwiftlyBinDir(in: pathCase.expectedPath)

            if let envScript {
                let command = if shell.hasSuffix("fish") {
                    """
                    set -gx PATH \(inputPath.joined(separator: " "))
                    source \(envScript.string)
                    string join : $PATH
                    """
                } else {
                    """
                    PATH='\(inputPath.joined(separator: ":"))'
                    . '\(envScript.string)'
                    printf '%s' "$PATH"
                    """
                }

                let result = try await Subprocess.run(
                    .path(FilePath(shell)),
                    arguments: ["-c", command],
                    output: .string(limit: 1024)
                )

                #expect(result.terminationStatus.isSuccess)

                let actualPath = result.standardOutput?
                    .replacing(/\n$/, with: "")
                    .split(separator: ":")
                    .map(String.init)

                #expect(actualPath == expectedPath)
            }
        }
    }
```

```console
$ swift test --filter InitTests.envPrependsSwiftlyBinDirAndRemovesDuplicates
...
✔ Test envPrependsSwiftlyBinDirAndRemovesDuplicates(shell:pathCase:) with 12 test cases passed after 0.190 seconds.
✔ Suite InitTests passed after 0.191 seconds.
✔ Test run with 1 test in 1 suite passed after 0.191 seconds.
```

Environment:

```console
$ uname -a
Linux Raspberry-beetle 6.18.34+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.18.34-1+rpt1 (2026-06-09) aarch64 GNU/Linux
$ fish --version
fish, version 4.8.0
$ zsh --version
zsh 5.9 (aarch64-unknown-linux-gnu)
$ bash --version
GNU bash, version 5.2.37(1)-release (aarch64-unknown-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```