### PR TITLE
[ubuntu] call abt-get update before abt-get install

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -304,7 +304,7 @@ public struct Linux: Platform {
             return nil
         }
 
-        var result: String = 
+        var result: String =
             switch platformName
         {
         case "ubuntu1804":


### PR DESCRIPTION
https://github.com/Swift-CowBox/Swift-CowBox/actions/runs/22457274995/job/65041728165

I started seeing consistent build failures from Ubuntu 24.04 on GitHub Actions:

```text
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  libcurl4-doc libidn-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 25 not upgraded.
Need to get 446 kB of archives.
After this operation, 1960 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-openssl-dev_8.5.0-2ubuntu10.6_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

I think what's happening is that `swiftly` is calling `apt-get install` without first calling `apt-get update`.[^1]

[^1]: <https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners#installing-software-on-ubuntu-runners>