### PR TITLE
Docs: fix broken links

### DIFF
--- a/Documentation/SwiftlyDocs.docc/getting-started.md
+++ b/Documentation/SwiftlyDocs.docc/getting-started.md
@@ -89,9 +89,9 @@ $ swiftly install main-snapshot
 
 ## See Also:
 
-- [Add shell autocompletions](shell-autocompletion)
-- [Install Toolchains](install-toolchains)
-- [Using Toolchains](use-toolchains)
-- [Uninstall Toolchains](uninstall-toolchains)
-- [Swiftly CLI Reference](swiftly-cli-reference)
+- <doc:shell-autocompletion>
+- <doc:install-toolchains>
+- <doc:use-toolchains>
+- <doc:uninstall-toolchains>
+- <doc:swiftly-cli-reference>
 

--- a/Documentation/SwiftlyDocs.docc/install-toolchains.md
+++ b/Documentation/SwiftlyDocs.docc/install-toolchains.md
@@ -4,7 +4,7 @@ Install swift toolchains with Swiftly.
 
 Installing a swift toolchain using swiftly involves downloading it securely and extracting it into a well-known location in your account.
 This guides you through the different ways you can install a swift toolchain.
-Follow the [Getting Started](getting-started.md) guide to install swiftly.
+Follow the <doc:getting-started> guide to install swiftly.
 
 The easiest way to install a swift toolchain is to select the latest stable release:
 


### PR DESCRIPTION
Links in various documents were being rendered with a broken link. Modify the link to use the `<doc:page>` syntax.