### PR TITLE
fix: swiftly is stuck during dependency check on Fedora

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -330,7 +330,7 @@ public struct Linux: Platform {
                 }
                 return false
             case "yum":
-                let result = try await run(.name("yum"), arguments: ["list", "installed", package], output: .discarded)
+                let result = try await run(.name("yum"), arguments: ["list", "--installed", package], output: .string(limit: 100 * 1024))
                 return result.terminationStatus.isSuccess
             default:
                 return true


### PR DESCRIPTION
Fix for https://github.com/swiftlang/swiftly/issues/490.

The underlying issue was that using `.discarded` instead of `.string(limit: 100 * 1024)` will hang when waiting for user input. I verified this by `run`ning a bash script which waits for user input instead of `yum list installed` (from the changed line). 
Since `result.standardOutput` is not currently being used the `limit: 100 * 1024` could be smaller, but for simplicity I used the same value as in the `apt-get` version.

Moreover, `yum list installed` is not fully correct. Compare the following:

```bash
> yum list installed libuuid-devel
Updating and loading repositories:
Repositories loaded.
Available packages
libuuid-devel.i686   2.40.4-10.fc42 updates
libuuid-devel.x86_64 2.40.4-10.fc42 updates
> echo $?
0
> yum list --installed libuuid-devel
No matching packages to list
> echo $?
1
```

This shows that using `--installed` instead of `installed` will correctly return a non 0 exit code if a package is not installed.