### PR TITLE
DNF: Switching Fedora and UBI9 to dnf instead of yum

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -254,9 +254,9 @@ public struct Linux: Platform {
         case "amazonlinux2":
             "yum"
         case "ubi9":
-            "yum"
+            "dnf"
         case "fedora39":
-            "yum"
+            "dnf"
         case "debian12":
             "apt-get"
         default:
@@ -329,6 +329,9 @@ public struct Linux: Platform {
                     return pkgList.contains("\nii ")
                 }
                 return false
+            case "dnf":
+                let result = try await run(.name("dnf"), arguments: ["list", "--installed", package], output: .discarded)
+                return result.terminationStatus.isSuccess
             case "yum":
                 let result = try await run(.name("yum"), arguments: ["list", "installed", package], output: .discarded)
                 return result.terminationStatus.isSuccess


### PR DESCRIPTION
Actual YUM and DNF take slightly different flags in some cases. Newer RPM-based distros tend to create a yum symlink that points at DNF, but in cases like `yum list` and `dnf list`, the `--installed` flag is available on `dnf`, but is spelled `installed` on `yum`. Passing `--installed` to `dnf list` will query the package repository for a package called "installed", which is not what we want to do.

Should help with https://github.com/swiftlang/swiftly/issues/528