### PR TITLE
Fedora41: Adding fedora41 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["ubuntu:22.04", "ubuntu:24.04", "redhat/ubi9", "debian:12", "fedora:39"]
+        container: ["ubuntu:22.04", "ubuntu:24.04", "redhat/ubi9", "debian:12", "fedora:39", "fedora:41"]
     container:
       image: ${{ matrix.container }}
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,6 +56,24 @@ jobs:
         # UBI 9 - See https://github.com/swiftlang/swift/issues/80909
         run: bash -c 'if [[ "${{ matrix.container }}" == "redhat/ubi9" ]]; then swift build --build-tests; else swift test; fi'
 
+  # Verify new platforms without a released Swiftly build
+  tests-bootstrapped:
+    name: Test (Bootstrapped) / ${{ matrix.container }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container: ["swiftlang/swift:nightly-6.3-fedora41"]
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Prepare the action
+        run: ./scripts/prep-gh-action.sh
+      - name: Build and Test
+        run: swift test
+
   releasebuildcheck:
     name: Release Build Check / Linux
     runs-on: ubuntu-latest

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -254,9 +254,9 @@ public struct Linux: Platform {
         case "amazonlinux2":
             "yum"
         case "ubi9":
-            "yum"
+            "dnf"
         case "fedora39":
-            "yum"
+            "dnf"
         case "debian12":
             "apt-get"
         default:
@@ -329,6 +329,9 @@ public struct Linux: Platform {
                     return pkgList.contains("\nii ")
                 }
                 return false
+            case "dnf":
+                let result = try await run(.name("dnf"), arguments: ["list", "--installed", package], output:.discarded)
+                return result.terminationStatus.isSuccess
             case "yum":
                 let result = try await run(.name("yum"), arguments: ["list", "installed", package], output: .discarded)
                 return result.terminationStatus.isSuccess

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -16,6 +16,7 @@ public struct Linux: Platform {
         .ubuntu2004,
         .ubuntu1804,
         .fedora39,
+        .fedora41,
         .rhel9,
         .amazonlinux2,
         .debian12,
@@ -200,7 +201,7 @@ public struct Linux: Platform {
                 "unzip",
                 "zip",
             ]
-        case "fedora39":
+        case "fedora39", "fedora41":
             [
                 "binutils",
                 "gcc",
@@ -255,7 +256,7 @@ public struct Linux: Platform {
             "yum"
         case "ubi9":
             "dnf"
-        case "fedora39":
+        case "fedora39", "fedora41":
             "dnf"
         case "debian12":
             "apt-get"
@@ -623,7 +624,13 @@ public struct Linux: Platform {
 
             return .rhel9
         } else if let pd = [
-            PlatformDefinition.ubuntu1804, .ubuntu2004, .ubuntu2204, .ubuntu2404, .debian12, .fedora39,
+            PlatformDefinition.ubuntu1804,
+                .ubuntu2004,
+                .ubuntu2204,
+                .ubuntu2404,
+                .debian12,
+                .fedora39,
+                .fedora41,
         ].first(where: { $0.name == id + versionID }) {
             return pd
         }

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -16,6 +16,7 @@ public struct Linux: Platform {
         .ubuntu2004,
         .ubuntu1804,
         .fedora39,
+        .fedora41,
         .rhel9,
         .amazonlinux2,
         .debian12,
@@ -200,7 +201,7 @@ public struct Linux: Platform {
                 "unzip",
                 "zip",
             ]
-        case "fedora39":
+        case "fedora39", "fedora41":
             [
                 "binutils",
                 "gcc",
@@ -255,7 +256,7 @@ public struct Linux: Platform {
             "yum"
         case "ubi9":
             "dnf"
-        case "fedora39":
+        case "fedora39", "fedora41":
             "dnf"
         case "debian12":
             "apt-get"
@@ -623,7 +624,13 @@ public struct Linux: Platform {
 
             return .rhel9
         } else if let pd = [
-            PlatformDefinition.ubuntu1804, .ubuntu2004, .ubuntu2204, .ubuntu2404, .debian12, .fedora39,
+            PlatformDefinition.ubuntu1804,
+            .ubuntu2004,
+            .ubuntu2204,
+            .ubuntu2404,
+            .debian12,
+            .fedora39,
+            .fedora41,
         ].first(where: { $0.name == id + versionID }) {
             return pd
         }

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -410,6 +410,10 @@ extension SwiftlyWebsiteAPI.Components.Schemas.Platform {
             PlatformDefinition(
                 name: "fedora39", nameFull: "fedora39", namePretty: "Fedora Linux 39"
             )
+        case "Fedora 41":
+            PlatformDefinition(
+                name: "fedora41", nameFull: "fedora41", namePretty: "Fedora Linux 41"
+            )
         default:
             nil
         }
@@ -550,7 +554,7 @@ public struct SwiftlyHTTPClient: Sendable {
         {
         // These are new platforms that aren't yet in the list of known platforms in the OpenAPI schema
         case PlatformDefinition.ubuntu2404.name, PlatformDefinition.debian12.name,
-             PlatformDefinition.fedora39.name:
+             PlatformDefinition.fedora39.name, PlatformDefinition.fedora41.name:
             .init(platform.name)
 
         case PlatformDefinition.ubuntu2204.name:

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -41,6 +41,9 @@ public struct PlatformDefinition: Codable, Equatable, Sendable {
     public static let fedora39 = PlatformDefinition(
         name: "fedora39", nameFull: "fedora39", namePretty: "Fedora Linux 39"
     )
+    public static let fedora41 = PlatformDefinition(
+        name: "fedora41", nameFull: "fedora41", namePretty: "Fedora Linux 41"
+    )
     public static let amazonlinux2 = PlatformDefinition(
         name: "amazonlinux2", nameFull: "amazonlinux2", namePretty: "Amazon Linux 2"
     )

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -130,35 +130,64 @@ import Testing
         }
     }
 
+    struct ToolchainSpecifier {
+        let platform: PlatformDefinition
+        let architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture]
+        let branches: [ToolchainVersion.Snapshot.Branch]
+
+        init(platform: PlatformDefinition,
+            architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture] = [.x8664, .aarch64],
+            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major:6, minor: 1)]) {
+            self.platform = platform
+            self.architectures = architectures
+            self.branches = branches
+        }
+
+        static let macOS = ToolchainSpecifier(platform: .macOS)
+        static let ubuntu2404 = ToolchainSpecifier(platform: .ubuntu2404)
+        static let ubuntu2204 = ToolchainSpecifier(platform: .ubuntu2204)
+        static let rhel9 = ToolchainSpecifier(platform: .rhel9)
+        static let fedora39 = ToolchainSpecifier(platform: .fedora39)
+        static let fedora41 = ToolchainSpecifier(platform: .fedora41,
+                                branches: [.release(major:6, minor: 3)])
+        static let amazonlinux2 = ToolchainSpecifier(platform: .amazonlinux2)
+        static let debian12 = ToolchainSpecifier(platform: .debian12)
+    }
+
     @Test(
         .tags(.large),
         arguments:
-        [PlatformDefinition.macOS, .ubuntu2404, .ubuntu2204, .rhel9, .fedora39, .amazonlinux2, .debian12],
-        [SwiftlyWebsiteAPI.Components.Schemas.Architecture.x8664, .aarch64]
-    ) func getToolchainMetdataFromSwiftOrg(_ platform: PlatformDefinition, _ arch: SwiftlyWebsiteAPI.Components.Schemas.Architecture) async throws {
+            [
+                ToolchainSpecifier.macOS,
+                .ubuntu2404,
+                .ubuntu2204,
+                .rhel9,
+                .fedora39,
+                .fedora41,
+                .amazonlinux2,
+                .debian12,
+            ]
+    ) func getToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
         guard case let pd = try await Swiftly.currentPlatform.detectPlatform(SwiftlyTests.ctx, disableConfirmation: true, platform: nil), pd != PlatformDefinition.rhel9 && pd != PlatformDefinition.ubuntu2004 else {
             return
         }
 
         let httpClient = SwiftlyHTTPClient(httpRequestExecutor: HTTPRequestExecutorImpl())
 
-        let branches: [ToolchainVersion.Snapshot.Branch] = [
-            .main,
-            .release(major: 6, minor: 1), // This is available in swift.org API
-        ]
-
         // GIVEN: we have a swiftly http client with swift.org metadata capability
         // WHEN: we ask for the first five releases of a supported platform in a supported arch
-        let releases = try await httpClient.getReleaseToolchains(platform: platform, arch: arch, limit: 5)
-        // THEN: we get at least 1 release
-        #expect(1 <= releases.count)
+        for arch in toolchainData.architectures {
+            let releases = try await httpClient.getReleaseToolchains(platform: toolchainData.platform, arch: arch, limit: 5)
+            // THEN: we get at least 1 release
+            #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
 
-        for branch in branches {
-            // GIVEN: we have a swiftly http client with swift.org metadata capability
-            // WHEN: we ask for the first five snapshots on a branch for a supported platform and arch
-            let snapshots = try await httpClient.getSnapshotToolchains(platform: platform, arch: arch.value2!, branch: branch, limit: 5)
-            // THEN: we get at least 3 releases
-            #expect(3 <= snapshots.count)
+            for branch in toolchainData.branches {
+                // GIVEN: we have a swiftly http client with swift.org metadata capability
+                // WHEN: we ask for the first five snapshots on a branch for a supported platform and arch
+                let snapshots = try await httpClient.getSnapshotToolchains(platform: toolchainData.platform, arch: arch.value2!, branch: branch, limit: 5)
+                // THEN: we get at least 3 releases
+                #expect(3 <= snapshots.count, "Found \(snapshots.count) snapshots, expected 3 for \(toolchainData.platform.name)[\(arch.value2!)")
+            }
         }
     }
 }

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -135,9 +135,11 @@ import Testing
         let architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture]
         let branches: [ToolchainVersion.Snapshot.Branch]
 
-        init(platform: PlatformDefinition,
+        init(
+            platform: PlatformDefinition,
             architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture] = [.x8664, .aarch64],
-            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major:6, minor: 1)]) {
+            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major: 6, minor: 1)]
+        ) {
             self.platform = platform
             self.architectures = architectures
             self.branches = branches
@@ -148,25 +150,26 @@ import Testing
         static let ubuntu2204 = ToolchainSpecifier(platform: .ubuntu2204)
         static let rhel9 = ToolchainSpecifier(platform: .rhel9)
         static let fedora39 = ToolchainSpecifier(platform: .fedora39)
-        static let fedora41 = ToolchainSpecifier(platform: .fedora41,
-                                branches: [.release(major:6, minor: 3)])
+        static let fedora41 = ToolchainSpecifier(
+            platform: .fedora41,
+            branches: [.release(major: 6, minor: 3)]
+        )
         static let amazonlinux2 = ToolchainSpecifier(platform: .amazonlinux2)
         static let debian12 = ToolchainSpecifier(platform: .debian12)
     }
 
     @Test(
         .tags(.large),
-        arguments:
-            [
-                ToolchainSpecifier.macOS,
-                .ubuntu2404,
-                .ubuntu2204,
-                .rhel9,
-                .fedora39,
-                .fedora41,
-                .amazonlinux2,
-                .debian12,
-            ]
+        arguments: [
+            ToolchainSpecifier.macOS,
+            .ubuntu2404,
+            .ubuntu2204,
+            .rhel9,
+            .fedora39,
+            .fedora41,
+            .amazonlinux2,
+            .debian12,
+        ]
     ) func getToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
         guard case let pd = try await Swiftly.currentPlatform.detectPlatform(SwiftlyTests.ctx, disableConfirmation: true, platform: nil), pd != PlatformDefinition.rhel9 && pd != PlatformDefinition.ubuntu2004 else {
             return

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -648,6 +648,8 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
             "Debian 12"
         case PlatformDefinition(name: "fedora39", nameFull: "fedora39", namePretty: "Fedora Linux 39"):
             "Fedora 39"
+        case PlatformDefinition(name: "fedora41", nameFull: "fedora41", namePretty: "Fedora Linux 41"):
+            "Fedora 41"
         case PlatformDefinition.macOS:
             "Xcode" // NOTE: this is not actually a platform that gets added in the swift.org API for macos/xcode
         default:


### PR DESCRIPTION
 Teaching Swiftly to recognize Fedora41 and adding it to the pull-request testing.

https://github.com/swiftlang/swiftly/issues/438