### PR TITLE
Print errors to stderr

### DIFF
--- a/Sources/Swiftly/Proxy.swift
+++ b/Sources/Swiftly/Proxy.swift
@@ -95,10 +95,10 @@ public enum Proxy {
                 exit(1)
             }
         } catch let error as SwiftlyError {
-            await ctx.message(error.message)
+            await ctx.printError(error.message)
             exit(1)
         } catch {
-            await ctx.message("\(error)")
+            await ctx.printError("\(error)")
             exit(1)
         }
     }


### PR DESCRIPTION
Previously these cases went to stdout, so error messages like:

```
.../.swift-version`
uses toolchain version 6.1, but it doesn't match any of the installed
toolchains. You can install the toolchain with `swiftly install`.
```

Would be lost unless you included captured stdout as well
