### PR TITLE
Use: Detect `Package.swift` as a project marker

### DIFF
--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -177,6 +177,7 @@ struct Use: SwiftlyCommand {
     }
 
     static func findNewVersionFile(_ ctx: SwiftlyCoreContext) async throws -> FilePath? {
+        let projectMarkers = [".git", "Package.swift"]
         var cwd = ctx.currentDirectory
 
         while !cwd.isEmpty && !cwd.removingRoot().isEmpty {
@@ -184,10 +185,10 @@ struct Use: SwiftlyCommand {
                 break
             }
 
-            let gitDir = cwd / ".git"
-
-            if try await fs.exists(atPath: gitDir) {
-                return cwd / ".swift-version"
+            for marker in projectMarkers {
+                if try await fs.exists(atPath: cwd / marker) {
+                    return cwd / ".swift-version"
+                }
             }
 
             cwd = cwd.removingLastComponent()

--- a/Tests/SwiftlyTests/UseTests.swift
+++ b/Tests/SwiftlyTests/UseTests.swift
@@ -324,6 +324,20 @@ import Testing
                 // THEN: the use command reports this toolchain to be in use
                 #expect(output.contains(where: { $0.contains(ToolchainVersion.newMainSnapshot.name) }))
 
+                // GIVEN: a directory with no swift version file but containing a Package.swift
+                try await fs.remove(atPath: versionFile)
+                let packageFile = SwiftlyTests.ctx.currentDirectory / "Package.swift"
+                try "// swift-tools-version:6.3".write(to: packageFile, atomically: true)
+                // WHEN: using a toolchain version
+                try await SwiftlyTests.runCommand(
+                    Use.self, ["use", ToolchainVersion.newReleaseSnapshot.name]
+                )
+                // THEN: a swift version file is created
+                #expect(try await fs.exists(atPath: versionFile))
+                // THEN: the version file contains the specified version
+                versionFileContents = try String(contentsOf: versionFile)
+                #expect(ToolchainVersion.newReleaseSnapshot.name == versionFileContents)
+
                 // GIVEN: a directory with no swift version file at the top of a git repository
                 try await fs.remove(atPath: versionFile)
                 let gitDir = SwiftlyTests.ctx.currentDirectory / ".git"


### PR DESCRIPTION
This PR fixes [issue#430](https://github.com/swiftlang/swiftly/issues/430)

Running `swiftly use <version>` before initialising git repository sets the global default instead of creating a local `.swift-version` file.
Address this short-coming by adding `Package.swift` to the set of markers that count as a project root.

### Fix demo:

https://github.com/user-attachments/assets/57f55c7f-bcf6-41b4-abf9-041e5c5d3748