### PR TITLE
Use: improve error message when .swift-version toolchain is missing

### DIFF
--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -257,7 +257,16 @@ public func selectToolchain(_ ctx: SwiftlyCoreContext, config: inout Config, glo
                 }
 
                 guard let selectedToolchain = config.listInstalledToolchains(selector: selector).max() else {
-                    return (nil, .swiftVersionFile(svFile, selector, SwiftlyError(message: "The swift version file `\(svFile)` uses toolchain version \(selector), but it doesn't match any of the installed toolchains. You can install the toolchain with `swiftly install`.")))
+                    let useSuggestion: String
+                    if case let .stable(major, minor?, _) = selector,
+                       let compatible = config.listInstalledToolchains(selector: ToolchainSelector(major: major, minor: minor)).max(),
+                       case let .stable(release) = compatible
+                    {
+                        useSuggestion = "`swiftly use \(release.major).\(release.minor).\(release.patch)`"
+                    } else {
+                        useSuggestion = "`swiftly use <version>`"
+                    }
+                    return (nil, .swiftVersionFile(svFile, selector, SwiftlyError(message: "The swift version file `\(svFile)` requires toolchain version \(selector), which is not installed. You can install it with `swiftly install`, or switch to a different installed toolchain with \(useSuggestion).")))
                 }
 
                 return (selectedToolchain, .swiftVersionFile(svFile, selector, nil))


### PR DESCRIPTION
When a swift version file references an uninstalled toolchain, the error
now suggests a compatible installed version (same major.minor) as a
concrete `swiftly use` command, rather than a generic placeholder.
Also clarifies the message to distinguish "not installed" from "doesn't match".