### PR TITLE
Swiftly-Use: JSON: Handle no selected toolchain

### DIFF
--- a/Sources/Swiftly/OutputSchema.swift
+++ b/Sources/Swiftly/OutputSchema.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftlyCore
 
+struct EmptyObject: OutputData {
+    var description: String { "" }
+}
+
 struct LocationInfo: OutputData {
     let path: String
 

--- a/Sources/Swiftly/Use.swift
+++ b/Sources/Swiftly/Use.swift
@@ -89,6 +89,7 @@ struct Use: SwiftlyCommand {
 
             guard let selectedVersion else {
                 // Return with nothing if there's no toolchain that is selected
+                try await ctx.output(EmptyObject())
                 return
             }
 

--- a/Tests/SwiftlyTests/UseTests.swift
+++ b/Tests/SwiftlyTests/UseTests.swift
@@ -351,6 +351,20 @@ import Testing
             }
     }
 
+    /// Tests that `swiftly use --format=json` emits a valid empty JSON object when no toolchain is selected.
+    @Test(.mockedSwiftlyVersion(), .mockHomeToolchains(toolchains: []))
+    func printInUseJsonFormatNoSelection() async throws {
+        let output = try await SwiftlyTests.runWithMockedIO(
+            Use.self, ["use", "--format", "json"], format: .json
+        )
+
+        let joined = output.joined(separator: "\n")
+        let data = try #require(joined.data(using: .utf8))
+        let json = try JSONSerialization.jsonObject(with: data)
+        let object = try #require(json as? [String: Any])
+        #expect(object.isEmpty)
+    }
+
     /// Tests that running a use command without an argument prints the currently in-use toolchain.
     @Test(.mockedSwiftlyVersion()) func printInUseJsonFormat() async throws {
         let toolchains = [


### PR DESCRIPTION
Uninstalling all of the tools in Swiftly and printing the current toolchain with `swiftly use --format=json` results in swiftly printing nothing. This is invalid JSON, so tools like the VSCode extension would emit an error.

Without the fix, the empty JSON passed to the Foundation JSON decoder emits the following error:

```
Caught error: Error Domain=NSCocoaErrorDomain Code=3840 "Unable to parse empty data." UserInfo={NSDebugDescription=Unable to parse empty data.}
```

fixes: #545