### PR TITLE
Report a friendly error for snapshot branches missing on swift.org

### DIFF
--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -205,20 +205,12 @@ public final class HTTPRequestExecutorImpl: HTTPRequestExecutor {
     ) async throws -> SwiftlyWebsiteAPI.Components.Schemas.DevToolchains {
         let response = try await self.websiteClient().listDevToolchains(
             .init(path: .init(branch: branch, platform: platform)))
-        return try Self.devToolchains(from: response, branch: branch)
-    }
 
-    /// Extract the development toolchains from a `listDevToolchains` response.
-    ///
-    /// swift.org responds with a 404 when there are no snapshots published for the requested
-    /// branch, which happens when the branch identifier doesn't exist (or is older than the
-    /// supported `main` and previous x.y releases). That response is surfaced as a typed
-    /// `SnapshotBranchNotFoundError` so callers can present an actionable message instead of the
-    /// raw, low-level HTTP failure.
-    static func devToolchains(
-        from response: SwiftlyWebsiteAPI.Operations.ListDevToolchains.Output,
-        branch: SwiftlyWebsiteAPI.Components.Schemas.SourceBranch
-    ) throws -> SwiftlyWebsiteAPI.Components.Schemas.DevToolchains {
+        // swift.org responds with a 404 when there are no snapshots published for the requested
+        // branch, which happens when the branch identifier doesn't exist (or is older than the
+        // supported `main` and previous x.y releases). Surface that as a typed
+        // `SnapshotBranchNotFoundError` so callers can present an actionable message instead of
+        // the raw, low-level HTTP failure.
         if case let .undocumented(statusCode, _) = response, statusCode == 404 {
             throw SwiftlyHTTPClient.SnapshotBranchNotFoundError(
                 branch: ToolchainVersion.Snapshot.Branch(branch))

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -205,6 +205,25 @@ public final class HTTPRequestExecutorImpl: HTTPRequestExecutor {
     ) async throws -> SwiftlyWebsiteAPI.Components.Schemas.DevToolchains {
         let response = try await self.websiteClient().listDevToolchains(
             .init(path: .init(branch: branch, platform: platform)))
+        return try Self.devToolchains(from: response, branch: branch)
+    }
+
+    /// Extract the development toolchains from a `listDevToolchains` response.
+    ///
+    /// swift.org responds with a 404 when there are no snapshots published for the requested
+    /// branch, which happens when the branch identifier doesn't exist (or is older than the
+    /// supported `main` and previous x.y releases). That response is surfaced as a typed
+    /// `SnapshotBranchNotFoundError` so callers can present an actionable message instead of the
+    /// raw, low-level HTTP failure.
+    static func devToolchains(
+        from response: SwiftlyWebsiteAPI.Operations.ListDevToolchains.Output,
+        branch: SwiftlyWebsiteAPI.Components.Schemas.SourceBranch
+    ) throws -> SwiftlyWebsiteAPI.Components.Schemas.DevToolchains {
+        if case let .undocumented(statusCode, _) = response, statusCode == 404 {
+            throw SwiftlyHTTPClient.SnapshotBranchNotFoundError(
+                branch: ToolchainVersion.Snapshot.Branch(branch))
+        }
+
         return try response.ok.body.json
     }
 
@@ -348,6 +367,28 @@ extension SwiftlyWebsiteAPI.Components.Schemas.SourceBranch {
 
     public init(_ string: String) {
         self.init(value2: string)
+    }
+}
+
+extension ToolchainVersion.Snapshot.Branch {
+    /// Reconstruct the snapshot branch from the swift.org `SourceBranch` that was used to request
+    /// it. This is the inverse of the mapping performed in `SwiftlyHTTPClient.getSnapshotToolchains`,
+    /// where `.main` becomes the `main` source branch and a release branch becomes its "major.minor"
+    /// string representation.
+    init(_ sourceBranch: SwiftlyWebsiteAPI.Components.Schemas.SourceBranch) {
+        let raw = sourceBranch.value1?.rawValue ?? sourceBranch.value2 ?? "main"
+
+        if raw == "main" {
+            self = .main
+            return
+        }
+
+        let components = raw.split(separator: ".")
+        if components.count == 2, let major = Int(components[0]), let minor = Int(components[1]) {
+            self = .release(major: major, minor: minor)
+        } else {
+            self = .main
+        }
     }
 }
 

--- a/Tests/SwiftlyTests/SnapshotBranchNotFoundTests.swift
+++ b/Tests/SwiftlyTests/SnapshotBranchNotFoundTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import OpenAPIRuntime
+@testable import SwiftlyCore
+import SwiftlyWebsiteAPI
+import Testing
+
+@Suite struct SnapshotBranchNotFoundTests {
+    typealias Output = SwiftlyWebsiteAPI.Operations.ListDevToolchains.Output
+    typealias SourceBranch = SwiftlyWebsiteAPI.Components.Schemas.SourceBranch
+
+    /// A 404 from the dev-toolchains endpoint, which swift.org returns for a branch that doesn't
+    /// exist, must be surfaced as a typed `SnapshotBranchNotFoundError` rather than the raw,
+    /// low-level HTTP error. This is the error the `install`, `list-available`, and `update`
+    /// commands catch to present an actionable message.
+    @Test func notFoundResponseMapsToTypedErrorForReleaseBranch() throws {
+        let response: Output = .undocumented(statusCode: 404, .init())
+        let sourceBranch = SourceBranch("9.9")
+
+        #expect(throws: SwiftlyHTTPClient.SnapshotBranchNotFoundError.self) {
+            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
+        }
+
+        do {
+            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
+            Issue.record("expected a SnapshotBranchNotFoundError to be thrown")
+        } catch let error as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
+            #expect(error.branch == .release(major: 9, minor: 9))
+        }
+    }
+
+    @Test func notFoundResponseMapsToTypedErrorForMainBranch() throws {
+        let response: Output = .undocumented(statusCode: 404, .init())
+        let sourceBranch = SourceBranch(.main)
+
+        do {
+            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
+            Issue.record("expected a SnapshotBranchNotFoundError to be thrown")
+        } catch let error as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
+            #expect(error.branch == .main)
+        }
+    }
+
+    /// A successful (200) response must still return the parsed toolchains untouched.
+    @Test func okResponseReturnsToolchains() throws {
+        let response: Output = .ok(.init(body: .json(.init())))
+        let result = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
+        #expect(result.universal == nil)
+        #expect(result.aarch64 == nil)
+        #expect(result.x8664 == nil)
+    }
+
+    /// Non-404 undocumented responses (for example a 5xx server error) should not be misreported
+    /// as a missing branch; they must propagate as the original error from `.ok`.
+    @Test func serverErrorIsNotReportedAsMissingBranch() throws {
+        let response: Output = .undocumented(statusCode: 500, .init())
+
+        #expect(throws: (any Error).self) {
+            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
+        }
+
+        do {
+            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
+            Issue.record("expected an error to be thrown for a 500 response")
+        } catch is SwiftlyHTTPClient.SnapshotBranchNotFoundError {
+            Issue.record("a 500 response must not be reported as a missing snapshot branch")
+        } catch {
+            // Expected: the generic unexpected-response error from the OpenAPI runtime.
+        }
+    }
+
+    /// The branch reconstruction is the inverse of how `SwiftlyHTTPClient.getSnapshotToolchains`
+    /// builds the `SourceBranch`, so the error carries the branch the caller actually requested.
+    @Test func branchReconstructionRoundTrips() throws {
+        #expect(ToolchainVersion.Snapshot.Branch(SourceBranch(.main)) == .main)
+        #expect(ToolchainVersion.Snapshot.Branch(SourceBranch("main")) == .main)
+        #expect(ToolchainVersion.Snapshot.Branch(SourceBranch("6.0")) == .release(major: 6, minor: 0))
+        #expect(ToolchainVersion.Snapshot.Branch(SourceBranch("9.9")) == .release(major: 9, minor: 9))
+    }
+}

--- a/Tests/SwiftlyTests/SnapshotBranchNotFoundTests.swift
+++ b/Tests/SwiftlyTests/SnapshotBranchNotFoundTests.swift
@@ -5,71 +5,13 @@ import SwiftlyWebsiteAPI
 import Testing
 
 @Suite struct SnapshotBranchNotFoundTests {
-    typealias Output = SwiftlyWebsiteAPI.Operations.ListDevToolchains.Output
     typealias SourceBranch = SwiftlyWebsiteAPI.Components.Schemas.SourceBranch
 
-    /// A 404 from the dev-toolchains endpoint, which swift.org returns for a branch that doesn't
-    /// exist, must be surfaced as a typed `SnapshotBranchNotFoundError` rather than the raw,
-    /// low-level HTTP error. This is the error the `install`, `list-available`, and `update`
-    /// commands catch to present an actionable message.
-    @Test func notFoundResponseMapsToTypedErrorForReleaseBranch() throws {
-        let response: Output = .undocumented(statusCode: 404, .init())
-        let sourceBranch = SourceBranch("9.9")
-
-        #expect(throws: SwiftlyHTTPClient.SnapshotBranchNotFoundError.self) {
-            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
-        }
-
-        do {
-            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
-            Issue.record("expected a SnapshotBranchNotFoundError to be thrown")
-        } catch let error as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
-            #expect(error.branch == .release(major: 9, minor: 9))
-        }
-    }
-
-    @Test func notFoundResponseMapsToTypedErrorForMainBranch() throws {
-        let response: Output = .undocumented(statusCode: 404, .init())
-        let sourceBranch = SourceBranch(.main)
-
-        do {
-            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: sourceBranch)
-            Issue.record("expected a SnapshotBranchNotFoundError to be thrown")
-        } catch let error as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
-            #expect(error.branch == .main)
-        }
-    }
-
-    /// A successful (200) response must still return the parsed toolchains untouched.
-    @Test func okResponseReturnsToolchains() throws {
-        let response: Output = .ok(.init(body: .json(.init())))
-        let result = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
-        #expect(result.universal == nil)
-        #expect(result.aarch64 == nil)
-        #expect(result.x8664 == nil)
-    }
-
-    /// Non-404 undocumented responses (for example a 5xx server error) should not be misreported
-    /// as a missing branch; they must propagate as the original error from `.ok`.
-    @Test func serverErrorIsNotReportedAsMissingBranch() throws {
-        let response: Output = .undocumented(statusCode: 500, .init())
-
-        #expect(throws: (any Error).self) {
-            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
-        }
-
-        do {
-            _ = try HTTPRequestExecutorImpl.devToolchains(from: response, branch: SourceBranch(.main))
-            Issue.record("expected an error to be thrown for a 500 response")
-        } catch is SwiftlyHTTPClient.SnapshotBranchNotFoundError {
-            Issue.record("a 500 response must not be reported as a missing snapshot branch")
-        } catch {
-            // Expected: the generic unexpected-response error from the OpenAPI runtime.
-        }
-    }
-
-    /// The branch reconstruction is the inverse of how `SwiftlyHTTPClient.getSnapshotToolchains`
-    /// builds the `SourceBranch`, so the error carries the branch the caller actually requested.
+    /// `getSnapshotToolchains` reconstructs the requested branch from the `SourceBranch` so the
+    /// `SnapshotBranchNotFoundError` it throws on a 404 carries the branch the caller actually
+    /// asked for. This round-trip is the inverse of how the `SourceBranch` is built, and is the
+    /// part with real logic, so it is worth pinning even though the 404 check itself is now a
+    /// straight inline pattern match in `getSnapshotToolchains`.
     @Test func branchReconstructionRoundTrips() throws {
         #expect(ToolchainVersion.Snapshot.Branch(SourceBranch(.main)) == .main)
         #expect(ToolchainVersion.Snapshot.Branch(SourceBranch("main")) == .main)


### PR DESCRIPTION
When you ask swiftly for a snapshot branch that isn't published on swift.org, you currently get a raw, low-level HTTP error rather than something you can act on:

```
$ swiftly list-available 9.9-snapshot
Error: Unexpected response, expected status code: ok, response: undocumented(statusCode: 404, OpenAPIRuntime.UndocumentedPayload(...))
```

The same thing happens for `swiftly install <branch>-snapshot` and when updating a snapshot whose branch has aged out.

The root cause is that `HTTPRequestExecutorImpl.getSnapshotToolchains` forwarded the response straight through `response.ok.body.json`. swift.org returns a 404 for the dev-toolchains endpoint when the branch doesn't exist (or is older than the supported `main` and previous x.y releases), and `.ok` then throws the generic OpenAPI runtime error.

Interestingly, `install`, `list-available`, and `update` already `catch SwiftlyHTTPClient.SnapshotBranchNotFoundError` and turn it into a clear, actionable message. But nothing ever threw that error, so all three catch blocks were dead code.

This change detects the 404 from `listDevToolchains` and throws `SnapshotBranchNotFoundError`, reconstructing the branch from the `SourceBranch` that was requested so the message names the branch the user actually typed. The reconstruction is the inverse of the `SourceBranch` mapping already done in `getSnapshotToolchains`. Non-404 responses (for example a 5xx server error) keep propagating as before, so a transient server problem is not misreported as a missing branch.

With the fix, the same command now reports:

```
$ swiftly list-available 9.9-snapshot
Error: The snapshot branch 9.9 development was not found on swift.org. Note that snapshot toolchains are only available for the current `main` release and the previous x.y (major.minor) release.
```

Verification: added `SnapshotBranchNotFoundTests`, which feeds a synthetic 404 `listDevToolchains` response through the response handler and asserts it maps to `SnapshotBranchNotFoundError` with the correct branch (both `main` and a release branch), that a 200 still returns the toolchains untouched, that a 500 is not reported as a missing branch, and that the `SourceBranch` to branch reconstruction round-trips. The new tests fail before the change (the raw 404 error escapes) and pass after. The rest of the suite (171 tests across 21 suites, excluding the network-tagged `HTTPClientTests`) continues to pass, and swiftformat reports no changes for the touched files.

Resolves #539