### PR TITLE
ToolchainVersion: Support x.y.z-snapshot version scheme

### DIFF
--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -299,8 +299,9 @@ struct Install: SwiftlyCommand {
                 category = "swift-\(versionString)-release"
             case let .snapshot(release):
                 switch release.branch {
-                case let .release(major, minor):
-                    category = "swift-\(major).\(minor)-branch"
+                case let .release(major, minor, patch):
+                    let patchPart = patch.map { ".\($0)" } ?? ""
+                    category = "swift-\(major).\(minor)\(patchPart)-branch"
                 case .main:
                     category = "development"
                 }

--- a/Sources/Swiftly/OutputSchema.swift
+++ b/Sources/Swiftly/OutputSchema.swift
@@ -128,6 +128,9 @@ struct AvailableToolchainInfo: OutputData {
             {
                 try versionContainer.encode(major, forKey: .major)
                 try versionContainer.encode(minor, forKey: .minor)
+                if let branchPatch = snapshot.branch.patch {
+                    try versionContainer.encode(branchPatch, forKey: .patch)
+                }
             }
         case .xcode:
             try versionContainer.encode("system", forKey: .type)
@@ -163,8 +166,8 @@ struct AvailableToolchainsListInfo: OutputData {
                 }
             case .snapshot(.main, nil):
                 "main development snapshot"
-            case let .snapshot(.release(major, minor), nil):
-                "\(major).\(minor) development snapshot"
+            case let .snapshot(.release(major, minor, patch), nil):
+                "\(major).\(minor)\(patch.map { ".\($0)" } ?? "") development snapshot"
             default:
                 "matching"
             }
@@ -242,6 +245,9 @@ struct InstallToolchainInfo: OutputData {
             {
                 try versionContainer.encode(major, forKey: .major)
                 try versionContainer.encode(minor, forKey: .minor)
+                if let branchPatch = snapshot.branch.patch {
+                    try versionContainer.encode(branchPatch, forKey: .patch)
+                }
             }
         case .xcode:
             try versionContainer.encode("system", forKey: .type)
@@ -278,7 +284,8 @@ struct InstallToolchainInfo: OutputData {
             if branchName == "main" {
                 branch = .main
             } else if let major = branchMajor, let minor = branchMinor {
-                branch = .release(major: major, minor: minor)
+                let branchPatch = try? versionContainer.decodeIfPresent(String.self, forKey: .patch)
+                branch = .release(major: major, minor: minor, patch: branchPatch)
             } else {
                 throw DecodingError.dataCorruptedError(
                     forKey: ToolchainVersionCodingKeys.branch,
@@ -328,8 +335,8 @@ struct InstalledToolchainsListInfo: OutputData {
                 }
             case .snapshot(.main, nil):
                 "main development snapshot"
-            case let .snapshot(.release(major, minor), nil):
-                "\(major).\(minor) development snapshot"
+            case let .snapshot(.release(major, minor, patch), nil):
+                "\(major).\(minor)\(patch.map { ".\($0)" } ?? "") development snapshot"
             case .xcode:
                 "xcode"
             default:

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -429,8 +429,8 @@ extension SwiftlyWebsiteAPI.Components.Schemas.Platform {
 }
 
 extension SwiftlyWebsiteAPI.Components.Schemas.DevToolchainForArch {
-    private static func snapshotRegex() -> Regex<(Substring, Substring?, Substring?, Substring)> {
-        try! Regex("swift(?:-(\\d+)\\.(\\d+))?-DEVELOPMENT-SNAPSHOT-(\\d{4}-\\d{2}-\\d{2})")
+    private static func snapshotRegex() -> Regex<(Substring, Substring?, Substring?, Substring?, Substring)> {
+        try! Regex("swift(?:-(\\d+)\\.(\\d+)(?:\\.([a-zA-Z0-9]+))?)?-DEVELOPMENT-SNAPSHOT-(\\d{4}-\\d{2}-\\d{2})")
     }
 
     func parseSnapshot() throws -> ToolchainVersion.Snapshot? {
@@ -444,12 +444,13 @@ extension SwiftlyWebsiteAPI.Components.Schemas.DevToolchainForArch {
                 throw SwiftlyError(
                     message: "malformatted release branch: \"\(majorString).\(minorString)\"")
             }
-            branch = .release(major: major, minor: minor)
+            let patch = match.output.3.map(String.init)
+            branch = .release(major: major, minor: minor, patch: patch)
         } else {
             branch = .main
         }
 
-        return ToolchainVersion.Snapshot(branch: branch, date: String(match.output.3))
+        return ToolchainVersion.Snapshot(branch: branch, date: String(match.output.4))
     }
 }
 
@@ -577,8 +578,8 @@ public struct SwiftlyHTTPClient: Sendable {
         {
         case .main:
             .init(.main)
-        case let .release(major, minor):
-            .init("\(major).\(minor)")
+        case let .release(major, minor, patch):
+            .init("\(major).\(minor)\(patch.map { ".\($0)" } ?? "")")
         }
 
         let devToolchains = try await self.httpRequestExecutor.getSnapshotToolchains(

--- a/Sources/SwiftlyCore/ToolchainVersion.swift
+++ b/Sources/SwiftlyCore/ToolchainVersion.swift
@@ -5,14 +5,15 @@ public enum ToolchainVersion: Sendable {
     public struct Snapshot: Equatable, Hashable, CustomStringConvertible, Comparable, Sendable {
         public enum Branch: Equatable, Hashable, CustomStringConvertible, Sendable {
             case main
-            case release(major: Int, minor: Int)
+            case release(major: Int, minor: Int, patch: String? = nil)
 
             public var description: String {
                 switch self {
                 case .main:
                     return "main"
-                case let .release(major, minor):
-                    return "\(major).\(minor) development"
+                case let .release(major, minor, patch):
+                    let patchPart = patch.map { ".\($0)" } ?? ""
+                    return "\(major).\(minor)\(patchPart) development"
                 }
             }
 
@@ -20,23 +21,31 @@ public enum ToolchainVersion: Sendable {
                 switch self {
                 case .main:
                     return "main"
-                case let .release(major, minor):
-                    return "\(major).\(minor)"
+                case let .release(major, minor, patch):
+                    let patchPart = patch.map { ".\($0)" } ?? ""
+                    return "\(major).\(minor)\(patchPart)"
                 }
             }
 
             public var major: Int? {
-                guard case let .release(major, _) = self else {
+                guard case let .release(major, _, _) = self else {
                     return nil
                 }
                 return major
             }
 
             public var minor: Int? {
-                guard case let .release(_, minor) = self else {
+                guard case let .release(_, minor, _) = self else {
                     return nil
                 }
                 return minor
+            }
+
+            public var patch: String? {
+                guard case let .release(_, _, patch) = self else {
+                    return nil
+                }
+                return patch
             }
         }
 
@@ -52,8 +61,9 @@ public enum ToolchainVersion: Sendable {
             switch self.branch {
             case .main:
                 return "main-snapshot-\(self.date)"
-            case let .release(major, minor):
-                return "\(major).\(minor)-snapshot-\(self.date)"
+            case let .release(major, minor, patch):
+                let patchPart = patch.map { ".\($0)" } ?? ""
+                return "\(major).\(minor)\(patchPart)-snapshot-\(self.date)"
             }
         }
 
@@ -110,8 +120,8 @@ public enum ToolchainVersion: Sendable {
         try! Regex("^main-snapshot-(\\d{4}-\\d{2}-\\d{2})$")
     }
 
-    static func releaseSnapshotRegex() -> Regex<(Substring, Substring, Substring, Substring)> {
-        try! Regex("^(\\d+)\\.(\\d+)-snapshot-(\\d{4}-\\d{2}-\\d{2})$")
+    static func releaseSnapshotRegex() -> Regex<(Substring, Substring, Substring, Substring?, Substring)> {
+        try! Regex("^(?:Swift )?(\\d+)\\.(\\d+)(?:\\.([a-zA-Z0-9]+))?-snapshot-(\\d{4}-\\d{2}-\\d{2})$")
     }
 
     /// Parse a toolchain version from the provided string.
@@ -134,7 +144,8 @@ public enum ToolchainVersion: Sendable {
             else {
                 throw SwiftlyError(message: "invalid release snapshot version: \(string)")
             }
-            self = ToolchainVersion(snapshotBranch: .release(major: major, minor: minor), date: String(match.output.3))
+            let patch = match.output.3.map(String.init)
+            self = ToolchainVersion(snapshotBranch: .release(major: major, minor: minor, patch: patch), date: String(match.output.4))
         } else if string == "xcode" {
             self = ToolchainVersion.xcodeVersion
         } else {
@@ -178,8 +189,9 @@ public enum ToolchainVersion: Sendable {
             switch release.branch {
             case .main:
                 return "main-snapshot-\(release.date)"
-            case let .release(major, minor):
-                return "\(major).\(minor)-snapshot-\(release.date)"
+            case let .release(major, minor, patch):
+                let patchPart = patch.map { ".\($0)" } ?? ""
+                return "\(major).\(minor)\(patchPart)-snapshot-\(release.date)"
             }
         case .xcode:
             return "xcode"
@@ -198,8 +210,9 @@ public enum ToolchainVersion: Sendable {
             switch release.branch {
             case .main:
                 return "swift-DEVELOPMENT-SNAPSHOT-\(release.date)-a"
-            case let .release(major, minor):
-                return "swift-\(major).\(minor)-DEVELOPMENT-SNAPSHOT-\(release.date)-a"
+            case let .release(major, minor, patch):
+                let patchPart = patch.map { ".\($0)" } ?? ""
+                return "swift-\(major).\(minor)\(patchPart)-DEVELOPMENT-SNAPSHOT-\(release.date)-a"
             }
         case .xcode:
             return "xcode"
@@ -425,6 +438,13 @@ struct StableReleaseParser: ToolchainSelectorParser {
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - a.b-DEVELOPMENT-SNAPSHOT
+///    - a.b.z-snapshot-YYYY-mm-dd
+///    - a.b.z-snapshot
+///    - a.b.z-SNAPSHOT-YYYY-mm-dd
+///    - a.b.z-SNAPSHOT
+///    - a.b.z-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
+///    - a.b.z-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
+///    - a.b.z-DEVELOPMENT-SNAPSHOT
 ///    - swift-a.b-snapshot-YYYY-mm-dd
 ///    - swift-a.b-snapshot
 ///    - swift-a.b-SNAPSHOT-YYYY-mm-dd
@@ -432,9 +452,16 @@ struct StableReleaseParser: ToolchainSelectorParser {
 ///    - swift-a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - swift-a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - swift-a.b-DEVELOPMENT-SNAPSHOT
+///    - swift-a.b.z-snapshot-YYYY-mm-dd
+///    - swift-a.b.z-snapshot
+///    - swift-a.b.z-SNAPSHOT-YYYY-mm-dd
+///    - swift-a.b.z-SNAPSHOT
+///    - swift-a.b.z-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
+///    - swift-a.b.z-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
+///    - swift-a.b.z-DEVELOPMENT-SNAPSHOT
 struct ReleaseSnapshotParser: ToolchainSelectorParser {
-    static func regex() -> Regex<(Substring, Substring, Substring, Substring?)> {
-        try! Regex("^(?:swift-)?([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
+    static func regex() -> Regex<(Substring, Substring, Substring, Substring?, Substring?)> {
+        try! Regex("^(?:swift-)?([0-9]+)\\.([0-9]+)(?:\\.([a-zA-Z0-9]+))?-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
     }
 
     func parse(_ input: String) throws -> ToolchainSelector? {
@@ -449,7 +476,8 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
             throw SwiftlyError(message: "malformatted version: \(match.output.1).\(match.output.2)")
         }
 
-        return .snapshot(branch: .release(major: major, minor: minor), date: match.output.3.map(String.init))
+        let patch = match.output.3.map(String.init)
+        return .snapshot(branch: .release(major: major, minor: minor, patch: patch), date: match.output.4.map(String.init))
     }
 }
 

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -147,6 +147,10 @@ import Testing
 
         static let macOS = ToolchainSpecifier(platform: .macOS)
         static let ubuntu2404 = ToolchainSpecifier(platform: .ubuntu2404)
+        static let ubuntu2404_6_4_x = ToolchainSpecifier(
+            platform: .ubuntu2404,
+            branches: [.release(major: 6, minor: 4, patch: "x")]
+        )
         static let ubuntu2204 = ToolchainSpecifier(platform: .ubuntu2204)
         static let rhel9 = ToolchainSpecifier(platform: .rhel9)
         static let fedora39 = ToolchainSpecifier(platform: .fedora39)
@@ -163,6 +167,7 @@ import Testing
         arguments: [
             ToolchainSpecifier.macOS,
             .ubuntu2404,
+            .ubuntu2404_6_4_x,
             .ubuntu2204,
             .rhel9,
             .fedora39,

--- a/Tests/SwiftlyTests/InstallTests.swift
+++ b/Tests/SwiftlyTests/InstallTests.swift
@@ -140,7 +140,7 @@ import Testing
 
         let installedToolchain = config.installedToolchains.first!
 
-        guard case let .snapshot(snapshot) = installedToolchain, snapshot.branch == .release(major: 6, minor: 0) else {
+        guard case let .snapshot(snapshot) = installedToolchain, snapshot.branch == .release(major: 6, minor: 0, patch: nil) else {
             Issue.record("expected swiftly install 6.0-snapshot to install snapshot toolchain but got \(installedToolchain)")
             return
         }

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -574,7 +574,7 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
     }
 
     private static func snapshotURLRegex() -> Regex<Substring> {
-        try! Regex("swift(?:-[0-9]+\\.[0-9]+)?-DEVELOPMENT-SNAPSHOT-[0-9]{4}-[0-9]{2}-[0-9]{2}")
+        try! Regex("swift(?:-[0-9]+\\.[0-9]+(?:\\.[a-zA-Z0-9]+)?)?-DEVELOPMENT-SNAPSHOT-[0-9]{4}-[0-9]{2}-[0-9]{2}")
     }
 
     private let executables: [String]
@@ -683,8 +683,8 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
             switch snapshotVersion.branch {
             case .main:
                 branch.value1 == .main || branch.value1?.rawValue == "main"
-            case let .release(major, minor):
-                branch.value2 == "\(major).\(minor)" || branch.value1?.rawValue == "\(major).\(minor)"
+            case let .release(major, minor, patch):
+                branch.value2 == "\(major).\(minor)\(patch.map { ".\($0)" } ?? "")" || branch.value1?.rawValue == "\(major).\(minor)\(patch.map { ".\($0)" } ?? "")"
             }
         }
 
@@ -694,7 +694,7 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
                 date: "",
                 dir: branch.value1 == .main || branch.value2 == "main" ?
                     "swift-DEVELOPMENT-SNAPSHOT-\(branchSnapshot.date)" :
-                    "swift-6.0-DEVELOPMENT-SNAPSHOT-\(branchSnapshot.date)",
+                    "swift-\(branchSnapshot.branch.name)-DEVELOPMENT-SNAPSHOT-\(branchSnapshot.date)",
                 download: "",
                 downloadSignature: nil,
                 debugInfo: nil

--- a/Tests/SwiftlyTests/ToolchainSelectorTests.swift
+++ b/Tests/SwiftlyTests/ToolchainSelectorTests.swift
@@ -48,7 +48,19 @@ import Testing
             "swift-5.7-SNAPSHOT",
             "swift-5.7-DEVELOPMENT-SNAPSHOT",
         ]
-        try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: nil), parses)
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7, patch: nil), date: nil), parses)
+    }
+
+    @Test func parseReleaseSnapshotWithPatch() throws {
+        let parses = [
+            "5.7.x-snapshot",
+            "5.7.x-SNAPSHOT",
+            "5.7.x-DEVELOPMENT-SNAPSHOT",
+            "swift-5.7.x-snapshot",
+            "swift-5.7.x-SNAPSHOT",
+            "swift-5.7.x-DEVELOPMENT-SNAPSHOT",
+        ]
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7, patch: "x"), date: nil), parses)
     }
 
     @Test func parseReleaseSnapshotWithDate() throws {
@@ -62,6 +74,20 @@ import Testing
             "swift-5.7-DEVELOPMENT-SNAPSHOT-2023-06-05",
             "swift-5.7-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
         ]
-        try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: "2023-06-05"), parses)
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7, patch: nil), date: "2023-06-05"), parses)
+    }
+
+    @Test func parseReleaseSnapshotWithPatchAndDate() throws {
+        let parses = [
+            "5.7.x-snapshot-2023-06-05",
+            "5.7.x-SNAPSHOT-2023-06-05",
+            "5.7.x-DEVELOPMENT-SNAPSHOT-2023-06-05",
+            "5.7.x-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+            "swift-5.7.x-snapshot-2023-06-05",
+            "swift-5.7.x-SNAPSHOT-2023-06-05",
+            "swift-5.7.x-DEVELOPMENT-SNAPSHOT-2023-06-05",
+            "swift-5.7.x-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+        ]
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7, patch: "x"), date: "2023-06-05"), parses)
     }
 }

--- a/Tests/SwiftlyTests/UninstallTests.swift
+++ b/Tests/SwiftlyTests/UninstallTests.swift
@@ -140,7 +140,7 @@ import Testing
             )
 
             let releaseSnapshots = installed.filter { toolchain in
-                guard case .release(major: 5, minor: 8) = toolchain.asSnapshot?.branch else {
+                guard case .release(major: 5, minor: 8, patch: _) = toolchain.asSnapshot?.branch else {
                     return false
                 }
                 return true

--- a/Tests/SwiftlyTests/UseTests.swift
+++ b/Tests/SwiftlyTests/UseTests.swift
@@ -174,17 +174,18 @@ import Testing
         )
         // Switch to the latest snapshot for the given release.
         guard
-            case let .release(major, minor) = ToolchainVersion.newReleaseSnapshot.asSnapshot!.branch
+            case let .release(major, minor, patch) = ToolchainVersion.newReleaseSnapshot.asSnapshot!.branch
         else {
             fatalError("expected release in snapshot release version")
         }
+        let patchPart = patch.map { ".\($0)" } ?? ""
         try await self.useAndValidate(
-            argument: "\(major).\(minor)-snapshot",
+            argument: "\(major).\(minor)\(patchPart)-snapshot",
             expectedVersion: .newReleaseSnapshot
         )
         // Switch to it again, assert no errors or changes were made.
         try await self.useAndValidate(
-            argument: "\(major).\(minor)-snapshot",
+            argument: "\(major).\(minor)\(patchPart)-snapshot",
             expectedVersion: .newReleaseSnapshot
         )
         // Switch to it again, this time by name. Assert no errors or changes were made.


### PR DESCRIPTION
Add optional patch component to Branch.release to handle the new x.y.z-snapshot naming scheme (e.g. 6.4.x-snapshot). Updates all parsers, identifiers, display strings, JSON encoding/decoding, and URL matching. Old x.y-snapshot format continues to work unchanged.


Resolves: 
```
swiftly install 6.4.x-snapshot             
Error: invalid toolchain selector: "6.4.x-snapshot"
```