### PR TITLE
Update tmpfile for swiftly pkg to use platform file extension

### DIFF
--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -113,7 +113,7 @@ struct SelfUpdate: SwiftlyCommand {
 
         guard let version, let downloadURL else { fatalError() }
 
-        let tmpFile = fs.mktemp()
+        let tmpFile = fs.mktemp(ext: ".\(Swiftly.currentPlatform.toolchainFileExtension)")
         try await fs.create(file: tmpFile, contents: nil)
         return try await fs.withTemporary(files: tmpFile) {
             let animation = PercentProgressAnimation(


### PR DESCRIPTION
When performing a self update make sure the swiftly pkg file has the appropriate pkg file extension