### PR TITLE
self-update: avoid redundant getCurrentSwiftlyRelease call in validateSwiftly

### DIFF
--- a/Sources/Swiftly/SelfUninstall.swift
+++ b/Sources/Swiftly/SelfUninstall.swift
@@ -21,7 +21,7 @@ struct SelfUninstall: SwiftlyCommand {
     }
 
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
-        _ = try await validateSwiftly(ctx)
+        _ = try await validateSwiftly(ctx, checkForUpdates: false)
         let swiftlyBin = Swiftly.currentPlatform.swiftlyBinDir(ctx)
 
         guard try await fs.exists(atPath: swiftlyBin) else {

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -29,7 +29,7 @@ struct SelfUpdate: SwiftlyCommand {
     }
 
     mutating func run(_ ctx: SwiftlyCoreContext) async throws {
-        try await validateSwiftly(ctx)
+        try await validateSwiftly(ctx, checkForUpdates: false)
 
         let swiftlyBin = Swiftly.currentPlatform.swiftlyBinDir(ctx) / "swiftly"
         guard try await fs.exists(atPath: swiftlyBin) else {

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -97,7 +97,7 @@ extension Data {
 
 extension SwiftlyCommand {
     @discardableResult
-    public mutating func validateSwiftly(_ ctx: SwiftlyCoreContext) async throws -> () -> Void {
+    public mutating func validateSwiftly(_ ctx: SwiftlyCoreContext, checkForUpdates: Bool = true) async throws -> () -> Void {
         for requiredDir in Swiftly.requiredDirectories(ctx) {
             guard try await fs.exists(atPath: requiredDir) else {
                 do {
@@ -113,7 +113,7 @@ extension SwiftlyCommand {
         _ = try await Config.load(ctx)
 
         let shouldUpdateSwiftly: Bool
-        if let swiftlyRelease = try? await ctx.httpClient.getCurrentSwiftlyRelease() {
+        if checkForUpdates, let swiftlyRelease = try? await ctx.httpClient.getCurrentSwiftlyRelease() {
             shouldUpdateSwiftly = try swiftlyRelease.swiftlyVersion > SwiftlyCore.version
         } else {
             shouldUpdateSwiftly = false

--- a/Tests/SwiftlyTests/SelfUpdateTests.swift
+++ b/Tests/SwiftlyTests/SelfUpdateTests.swift
@@ -1,9 +1,34 @@
 import AsyncHTTPClient
 import Foundation
 import NIO
+import OpenAPIRuntime
 @testable import Swiftly
 @testable import SwiftlyCore
+import SwiftlyWebsiteAPI
 import Testing
+
+/// Wraps MockToolchainDownloader and tracks how many times getCurrentSwiftlyRelease is called.
+private final actor UpdateCheckTracker: HTTPRequestExecutor {
+    var updateCheckCount = 0
+    private let base: MockToolchainDownloader
+
+    init(latestSwiftlyVersion: SwiftlyVersion = SwiftlyCore.version) {
+        self.base = MockToolchainDownloader(latestSwiftlyVersion: latestSwiftlyVersion)
+    }
+
+    func getCurrentSwiftlyRelease() async throws -> Components.Schemas.SwiftlyRelease {
+        self.updateCheckCount += 1
+        return try await self.base.getCurrentSwiftlyRelease()
+    }
+
+    func getReleaseToolchains() async throws -> [Components.Schemas.Release] { try await self.base.getReleaseToolchains() }
+    func getSnapshotToolchains(branch: Components.Schemas.SourceBranch, platform: Components.Schemas.PlatformIdentifier) async throws -> Components.Schemas.DevToolchains { try await self.base.getSnapshotToolchains(branch: branch, platform: platform) }
+    func getGpgKeys() async throws -> HTTPBody { try await self.base.getGpgKeys() }
+    func getSwiftlyRelease(url: URL) async throws -> HTTPBody { try await self.base.getSwiftlyRelease(url: url) }
+    func getSwiftlyReleaseSignature(url: URL) async throws -> HTTPBody { try await self.base.getSwiftlyReleaseSignature(url: url) }
+    func getSwiftToolchainFile(_ toolchainFile: ToolchainFile) async throws -> HTTPBody { try await self.base.getSwiftToolchainFile(toolchainFile) }
+    func getSwiftToolchainFileSignature(_ toolchainFile: ToolchainFile) async throws -> HTTPBody { try await self.base.getSwiftToolchainFileSignature(toolchainFile) }
+}
 
 @Suite struct SelfUpdateTests {
     private static var newMajorVersion: SwiftlyVersion {
@@ -61,6 +86,55 @@ import Testing
                 // THEN: swiftly is updated to the new version
                 #expect(updatedVersion == Self.newDevVersion)
             }
+        }
+    }
+
+    /// Verify that validateSwiftly does not call getCurrentSwiftlyRelease when checkForUpdates is false,
+    /// and does call it when checkForUpdates is true.
+    @Test func validateSwiftlyRespectsCheckForUpdatesFlag() async throws {
+        try await SwiftlyTests.withTestHome {
+            let tracker = UpdateCheckTracker()
+            let ctx = SwiftlyCoreContext(
+                mockedHomeDir: SwiftlyTests.ctx.mockedHomeDir,
+                httpRequestExecutor: tracker,
+                outputHandler: SwiftlyTests.ctx.outputHandler,
+                inputProvider: SwiftlyTests.ctx.inputProvider
+            )
+
+            var command = SelfUpdate()
+
+            // WHEN: validateSwiftly is called with checkForUpdates: false (as SelfUpdate.run does)
+            _ = try await command.validateSwiftly(ctx, checkForUpdates: false)
+
+            // THEN: the swiftly release endpoint was not called
+            #expect(await tracker.updateCheckCount == 0)
+
+            // WHEN: validateSwiftly is called with the default checkForUpdates: true
+            _ = try await command.validateSwiftly(ctx)
+
+            // THEN: the swiftly release endpoint was called exactly once
+            #expect(await tracker.updateCheckCount == 1)
+        }
+    }
+
+    /// Verify that self-update does not make a redundant call to getCurrentSwiftlyRelease via validateSwiftly.
+    /// Before the fix, validateSwiftly would call getCurrentSwiftlyRelease for every subcommand,
+    /// resulting in two calls during self-update (one from validateSwiftly, one from SelfUpdate.execute).
+    @Test func selfUpdateChecksForUpdatesExactlyOnce() async throws {
+        try await SwiftlyTests.withTestHome {
+            let tracker = UpdateCheckTracker()
+            let ctx = SwiftlyCoreContext(
+                mockedHomeDir: SwiftlyTests.ctx.mockedHomeDir,
+                httpRequestExecutor: tracker,
+                outputHandler: SwiftlyTests.ctx.outputHandler,
+                inputProvider: SwiftlyTests.ctx.inputProvider
+            )
+
+            // WHEN: self-update runs (already up to date)
+            _ = try await SelfUpdate.execute(ctx, verbose: false, version: nil)
+
+            // THEN: getCurrentSwiftlyRelease was called exactly once (by SelfUpdate.execute, not validateSwiftly)
+            #expect(await tracker.updateCheckCount == 1)
         }
     }
 }

--- a/Tests/SwiftlyTests/SelfUpdateTests.swift
+++ b/Tests/SwiftlyTests/SelfUpdateTests.swift
@@ -117,10 +117,12 @@ private final actor UpdateCheckTracker: HTTPRequestExecutor {
         }
     }
 
-    /// Verify that self-update does not make a redundant call to getCurrentSwiftlyRelease via validateSwiftly.
+    /// Verify that SelfUpdate.execute does not make more than one call to getCurrentSwiftlyRelease.
     /// Before the fix, validateSwiftly would call getCurrentSwiftlyRelease for every subcommand,
     /// resulting in two calls during self-update (one from validateSwiftly, one from SelfUpdate.execute).
-    @Test func selfUpdateChecksForUpdatesExactlyOnce() async throws {
+    /// This test exercises execute directly; validateSwiftlyRespectsCheckForUpdatesFlag covers the
+    /// checkForUpdates: false guard in validateSwiftly itself.
+    @Test func selfUpdateExecuteChecksForUpdatesExactlyOnce() async throws {
         try await SwiftlyTests.withTestHome {
             let tracker = UpdateCheckTracker()
             let ctx = SwiftlyCoreContext(


### PR DESCRIPTION
Fixes #538

## Problem

`SelfUpdate.run` called `validateSwiftly(ctx)`, which makes an HTTP request to
`getCurrentSwiftlyRelease()` to check for a newer swiftly. It then immediately
calls `SelfUpdate.execute`, which makes the same call. The result from
`validateSwiftly` was discarded (the returned closure was never invoked in
`run`), so the first call was pure waste.

`SelfUninstall.run` had the same issue — it called `validateSwiftly(ctx)` and
discarded the returned closure, paying the network cost for no user-visible
benefit.

## Fix

Add `checkForUpdates: Bool = true` to `validateSwiftly`. All existing callers
that use the returned closure are unaffected (default is `true`). `SelfUpdate`
and `SelfUninstall` pass `checkForUpdates: false` since they either handle the
check themselves (`SelfUpdate.execute`) or never show the update banner
(`SelfUninstall`).

## Tests

- `validateSwiftlyRespectsCheckForUpdatesFlag` — verifies that `validateSwiftly(ctx, checkForUpdates: false)` makes zero calls and `validateSwiftly(ctx)` makes one
- `selfUpdateExecuteChecksForUpdatesExactlyOnce` — verifies `SelfUpdate.execute` makes exactly one call end-to-end

Note: this is unrelated to PR #506, which adds a user-facing flag to skip update checks on slow connections. This fix removes an unconditional redundant call that the user had no way to avoid.