### PR TITLE
Bump Swiftly to Swift-Subprocess 1.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8d862702b4248c3d083113634780649da3f9befc302a22151dd1923de27cd91f",
+  "originHash" : "906e3d197a79a31a6fbaca1f845a75ee638c771fe3975c427b77ad7b9abaae22",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-subprocess",
       "state" : {
-        "revision" : "ba5888ad7758cbcbe7abebac37860b1652af2d9c",
-        "version" : "0.3.0"
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.7.2"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.2"),
         .package(url: "https://github.com/apple/swift-system", from: "1.4.2"),
-        .package(url: "https://github.com/swiftlang/swift-subprocess", exact: "0.3.0", traits: []),
+        .package(url: "https://github.com/swiftlang/swift-subprocess", exact: "1.0.0", traits: []),
         // This dependency provides the correct version of the formatter so that you can run `swift run swiftformat Package.swift Plugins/ Sources/ Tests/`
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.49.18"),
     ],

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -317,19 +317,20 @@ public struct Linux: Platform {
                     return false
                 }
 
-                if let pkgList = result.standardOutput {
-                    // The package might be listed but not in an installed non-error state.
-                    //
-                    // Look for something like this:
-                    //
-                    //   Desired=Unknown/Install/Remove/Purge/Hold
-                    //   | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
-                    //   |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
-                    //   ||/
-                    //   ii  pkgfoo         1.0.0ubuntu12        My description goes here....
-                    return pkgList.contains("\nii ")
+                let pkgList = result.standardOutput
+                guard !pkgList.isEmpty else {
+                    return false
                 }
-                return false
+                // The package might be listed but not in an installed non-error state.
+                //
+                // Look for something like this:
+                //
+                //   Desired=Unknown/Install/Remove/Purge/Hold
+                //   | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+                //   |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+                //   ||/
+                //   ii  pkgfoo         1.0.0ubuntu12        My description goes here....
+                return pkgList.contains("\nii ")
             case "dnf":
                 let result = try await run(.name("dnf"), arguments: ["list", "--installed", package], output: .discarded)
                 return result.terminationStatus.isSuccess
@@ -400,7 +401,7 @@ public struct Linux: Platform {
                 arguments: ["init"]
             )
 
-            let result = try await run(config, output: .standardOutput, error: .standardError)
+            let result = try await run(config, output: .currentStandardOutput, error: .currentStandardError)
             if !result.terminationStatus.isSuccess {
                 throw RunProgramError(terminationStatus: result.terminationStatus, config: config)
             }

--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -74,9 +74,9 @@ public struct MacOS: Platform {
             await ctx.message(msg)
         }
 
-        let sdkPath = result.standardOutput?.replacingOccurrences(of: "\n", with: "")
+        let sdkPath = result.standardOutput.replacingOccurrences(of: "\n", with: "")
 
-        if sdkPath == nil {
+        if sdkPath.isEmpty {
             await ctx.message("WARNING: Could not read output of '/usr/bin/xcrun --show-sdk-path --sdk macosx'. Ensure your macOS SDK is installed properly for the swift toolchain to work.")
         }
 
@@ -172,9 +172,9 @@ public struct MacOS: Platform {
         }
 
         let config = Configuration(
-            .path(FilePath((userHomeDir / ".swiftly/bin/swiftly").string)), arguments: ["init"]
+            executable: .path(FilePath((userHomeDir / ".swiftly/bin/swiftly").string)), arguments: ["init"]
         )
-        let result = try await run(config, input: .standardInput, output: .standardOutput, error: .standardError)
+        let result = try await run(config, input: .currentStandardInput, output: .currentStandardOutput, error: .currentStandardError)
         if !result.terminationStatus.isSuccess {
             throw RunProgramError(terminationStatus: result.terminationStatus, config: config)
         }
@@ -274,7 +274,7 @@ public struct MacOS: Platform {
                     .path(SystemPackage.FilePath("/usr/bin/xcrun")),
                     arguments: ["--show-sdk-path"],
                     output: .string(limit: 1024 * 10)
-                ).standardOutput?.replacingOccurrences(of: "\n", with: ""),
+                ).standardOutput.replacingOccurrences(of: "\n", with: ""),
             ])
         }
 

--- a/Sources/Swiftly/Proxy.swift
+++ b/Sources/Swiftly/Proxy.swift
@@ -72,16 +72,16 @@ public enum Proxy {
             let env = try await Swiftly.currentPlatform.proxyEnvironment(ctx, env: .inherit, toolchain: toolchain)
 
             let cmdConfig = Configuration(
-                .name(binName),
+                executable: .name(binName),
                 arguments: Arguments(Array(CommandLine.arguments[1...])),
                 environment: env.updating(["SWIFTLY_PROXY_IN_PROGRESS": "1"])
             )
 
             let cmdResult = try await Subprocess.run(
                 cmdConfig,
-                input: .standardInput,
-                output: .standardOutput,
-                error: .standardError
+                input: .currentStandardInput,
+                output: .currentStandardOutput,
+                error: .currentStandardError
             )
 
             if !cmdResult.terminationStatus.isSuccess {
@@ -91,7 +91,7 @@ public enum Proxy {
             switch terminated.terminationStatus {
             case let .exited(code):
                 exit(code)
-            case .unhandledException:
+            case .signaled:
                 exit(1)
             }
         } catch let error as SwiftlyError {

--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -125,8 +125,13 @@ struct Run: SwiftlyCommand {
         )
 
         if let outputHandler = ctx.outputHandler {
-            let result = try await Subprocess.run(processConfig) { _, output in
-                for try await line in output.lines() {
+            let result = try await Subprocess.run(
+                processConfig,
+                input: .none,
+                output: .sequence,
+                error: .currentStandardError
+            ) { execution in
+                for try await line in execution.standardOutput.strings() {
                     await outputHandler.handleOutputLine(line.replacing("\n", with: ""))
                 }
             }
@@ -138,7 +143,7 @@ struct Run: SwiftlyCommand {
             return
         }
 
-        let result = try await Subprocess.run(processConfig, input: .standardInput, output: .standardOutput, error: .standardError)
+        let result = try await Subprocess.run(processConfig, input: .currentStandardInput, output: .currentStandardOutput, error: .currentStandardError)
         if !result.terminationStatus.isSuccess {
             throw RunProgramError(terminationStatus: result.terminationStatus, config: processConfig)
         }

--- a/Sources/SwiftlyCore/ModeledCommandLine.swift
+++ b/Sources/SwiftlyCore/ModeledCommandLine.swift
@@ -16,7 +16,7 @@ extension Runnable {
         input: Input = .none,
         output: Output,
         error: Error = .discarded
-    ) async throws -> CollectedResult<Output, Error> {
+    ) async throws -> ExecutionResult<Void, Output, Error> {
         var c = self.config()
 
         // TODO: someday the configuration might have its own environment from the modeled commands. That will require this to be able to merge the environment from the commands with the provided environment.
@@ -40,7 +40,7 @@ extension Runnable {
         c.environment = environment
 
         if !quiet {
-            let result = try await Subprocess.run(c, input: .standardInput, output: .standardOutput, error: .standardError)
+            let result = try await Subprocess.run(c, input: .currentStandardInput, output: .currentStandardOutput, error: .currentStandardError)
             if !result.terminationStatus.isSuccess {
                 throw RunProgramError(terminationStatus: result.terminationStatus, config: c)
             }
@@ -70,7 +70,7 @@ extension Output {
             let result = try await Subprocess.run(
                 self.config(),
                 output: .string(limit: limit),
-                error: .standardError
+                error: .currentStandardError
             )
 
             if !result.terminationStatus.isSuccess {
@@ -97,7 +97,7 @@ extension Output {
         environment: Environment = .inherit,
         limit _: Int,
         quiet: Bool = false,
-        body: (AsyncBufferSequence) -> Void
+        body: (SubprocessOutputSequence) -> Void
     ) async throws {
         var c = self.config()
 
@@ -107,9 +107,11 @@ extension Output {
         if !quiet {
             let result = try await Subprocess.run(
                 self.config(),
-                error: .standardError
-            ) { _, sequence in
-                body(sequence)
+                input: .none,
+                output: .sequence,
+                error: .currentStandardError
+            ) { execution in
+                body(execution.standardOutput)
             }
 
             if !result.terminationStatus.isSuccess {
@@ -118,9 +120,11 @@ extension Output {
         } else {
             let result = try await Subprocess.run(
                 self.config(),
+                input: .none,
+                output: .sequence,
                 error: .discarded
-            ) { _, sequence in
-                body(sequence)
+            ) { execution in
+                body(execution.standardOutput)
             }
 
             if !result.terminationStatus.isSuccess {

--- a/Sources/TestSwiftly/TestSwiftly.swift
+++ b/Sources/TestSwiftly/TestSwiftly.swift
@@ -124,11 +124,11 @@ struct TestSwiftly: AsyncParsableCommand {
             ])
 
             let config = Configuration(
-                .path(extractedSwiftly),
+                executable: .path(extractedSwiftly),
                 arguments: ["init", "--assume-yes", "--no-modify-profile", "--skip-install"],
                 environment: env
             )
-            let result = try await Subprocess.run(config, output: .standardOutput, error: .standardError)
+            let result = try await Subprocess.run(config, output: .currentStandardOutput, error: .currentStandardError)
             if !result.terminationStatus.isSuccess {
                 throw RunProgramError(terminationStatus: result.terminationStatus, config: config)
             }
@@ -145,11 +145,11 @@ struct TestSwiftly: AsyncParsableCommand {
             }
 
             let config = Configuration(
-                .path(extractedSwiftly),
+                executable: .path(extractedSwiftly),
                 arguments: ["init", "--assume-yes", "--skip-install"],
                 environment: env
             )
-            let result = try await Subprocess.run(config, output: .standardOutput, error: .standardError)
+            let result = try await Subprocess.run(config, output: .currentStandardOutput, error: .currentStandardError)
             if !result.terminationStatus.isSuccess {
                 throw RunProgramError(terminationStatus: result.terminationStatus, config: config)
             }
@@ -160,8 +160,8 @@ struct TestSwiftly: AsyncParsableCommand {
 
         if NSUserName() == "root" {
             if try await fs.exists(atPath: "./post-install.sh") {
-                let config = Configuration(.path(shell), arguments: ["./post-install.sh"])
-                let result = try await Subprocess.run(config, input: .standardInput, output: .standardOutput, error: .standardError)
+                let config = Configuration(executable: .path(shell), arguments: ["./post-install.sh"])
+                let result = try await Subprocess.run(config, input: .currentStandardInput, output: .currentStandardOutput, error: .currentStandardError)
                 if !result.terminationStatus.isSuccess {
                     throw RunProgramError(terminationStatus: result.terminationStatus, config: config)
                 }

--- a/Tests/SwiftlyTests/CommandLineTests.swift
+++ b/Tests/SwiftlyTests/CommandLineTests.swift
@@ -142,9 +142,16 @@ public struct CommandLineTests {
 
         // AND a simple history
         try "Some text".write(to: tmp / "foo.txt", atomically: true)
-        try #require(try await run(.name("git"), arguments: ["-C", "\(tmp)", "add", "foo.txt"], output: .standardOutput).terminationStatus.isSuccess)
-        try #require(try await run(.name("git"), arguments: ["-C", "\(tmp)", "config", "--local", "user.email", "user@example.com"], output: .standardOutput).terminationStatus.isSuccess)
-        try #require(try await run(.name("git"), arguments: ["-C", "\(tmp)", "config", "--local", "commit.gpgsign", "false"], output: .standardOutput).terminationStatus.isSuccess)
+        try #require(try await run(.name("git"), arguments: ["-C", "\(tmp)", "add", "foo.txt"], output: .currentStandardOutput).terminationStatus.isSuccess)
+        try #require(try await run(.name("git"), arguments: [
+            "-C",
+            "\(tmp)",
+            "config",
+            "--local",
+            "user.email",
+            "user@example.com",
+        ], output: .currentStandardOutput).terminationStatus.isSuccess)
+        try #require(try await run(.name("git"), arguments: ["-C", "\(tmp)", "config", "--local", "commit.gpgsign", "false"], output: .currentStandardOutput).terminationStatus.isSuccess)
         try await sys.git(.workingDir(tmp)).commit(.message("Initial commit")).run()
         try await sys.git(.workingDir(tmp)).diffindex(.quiet, tree_ish: "HEAD").run()
 
@@ -270,7 +277,7 @@ public struct CommandLineTests {
     func testSwift() async throws {
         let tmp = fs.mktemp()
         try await fs.mkdir(atPath: tmp)
-        let swiftExec: Executable = .path(try Executable.name("swift").resolveExecutablePath(in: .inherit))
+        let swiftExec: Executable = .path(try await Executable.name("swift").resolveExecutablePath(in: .inherit))
         try await sys.swift(executable: swiftExec).package()._init(.package_path(tmp), .type("executable")).run()
         try await sys.swift(executable: swiftExec).build(.package_path(tmp), .configuration("release")).run()
     }

--- a/Tests/SwiftlyTests/RunTests.swift
+++ b/Tests/SwiftlyTests/RunTests.swift
@@ -94,7 +94,7 @@ import Testing
         // Test --help is handled correctly
         do {
             try await SwiftlyTests.runCommand(Run.self, ["run", "--help"])
-            #expect(false)
+            #expect(Bool(false))
         } catch {
             #expect(error is CleanExit)
         }
@@ -102,7 +102,7 @@ import Testing
         // Test -h is handled correctly
         do {
             try await SwiftlyTests.runCommand(Run.self, ["run", "-h"])
-            #expect(false)
+            #expect(Bool(false))
         } catch {
             #expect(error is CleanExit)
         }
@@ -113,7 +113,7 @@ import Testing
         // Test --version is handled correctly
         do {
             try await SwiftlyTests.runCommand(Run.self, ["run", "--version"])
-            #expect(false)
+            #expect(Bool(false))
         } catch {
             #expect(error is CleanExit)
         }

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -28,7 +28,7 @@ extension Tag {
 
 extension Subprocess.Executable {
     public func exists() async throws -> Bool {
-        (try? self.resolveExecutablePath(in: .inherit)) != nil
+        (try? await self.resolveExecutablePath(in: .inherit)) != nil
     }
 }
 

--- a/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
+++ b/Tools/build-swiftly-release/BuildSwiftlyRelease.swift
@@ -178,12 +178,12 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         let swiftVerRegex: Regex<(Substring, Substring)> = try! Regex("Swift version (\\d+\\.\\d+\\.?\\d*) ")
 
         let swiftVersionCmd = Configuration(
-            .name("swift"),
+            executable: .name("swift"),
             arguments: ["--version"]
         )
         print("\(swiftVersionCmd.executable) \(swiftVersionCmd.arguments)")
 
-        let swiftVerOutput = (try await Subprocess.run(swiftVersionCmd, output: .string(limit: 1024))).standardOutput ?? ""
+        let swiftVerOutput = (try await Subprocess.run(swiftVersionCmd, output: .string(limit: 1024))).standardOutput
         guard let swiftVerMatch = try swiftVerRegex.firstMatch(in: swiftVerOutput) else {
             throw Error(message: "Unable to detect swift version")
         }
@@ -237,7 +237,7 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
         ])
 
         let configCmd = Configuration(
-            .path(FilePath("./configure")),
+            executable: .path(FilePath("./configure")),
             arguments: [
                 "--prefix=\(pkgConfigPath)",
                 "--enable-shared=no",
@@ -263,8 +263,8 @@ struct BuildSwiftlyRelease: AsyncParsableCommand {
 
         let result = try await Subprocess.run(
             configCmd,
-            output: .standardOutput,
-            error: .standardError,
+            output: .currentStandardOutput,
+            error: .currentStandardError,
         )
 
         if !result.terminationStatus.isSuccess {


### PR DESCRIPTION
Bumping Swiftly to use Subprocess 1.0.0 and fixing the API changes associated with that.
Subprocess 1.0.0 contains fixes for running on older kernels like the one on Amazon Linux  2 among the other changes.

 - Adding the named `executable` argument name to `Configuration` construction.
 - Migrating `.standardInput`, `.standardOutput`, and `.standardError` to the new `.currentStandardInput`, `.currentStandardOutput`, and `.currentStandardError` names.
 - Using the single execution context passed into the closure instead of the separate stderr/stdout streams.
 - Migrating from `CollectedResult` to `ExecutionResult` type.
 - Adding await to `Executable.resolveExecutablePath`, which is now an async function.