### PR TITLE
Handle install 6.4-snapshot properly

### DIFF
--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -496,7 +496,9 @@ struct Install: SwiftlyCommand {
             do {
                 snapshots = try await ctx.httpClient.getSnapshotToolchains(
                     platform: config.platform, branch: branch, limit: 1
-                )
+                ) { snapshot in
+                    snapshot.branch == branch
+                }
             } catch let branchNotFoundErr as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
                 throw SwiftlyError(
                     message:

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -496,9 +496,7 @@ struct Install: SwiftlyCommand {
             do {
                 snapshots = try await ctx.httpClient.getSnapshotToolchains(
                     platform: config.platform, branch: branch, limit: 1
-                ) { snapshot in
-                    snapshot.branch == branch
-                }
+                )
             } catch let branchNotFoundErr as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
                 throw SwiftlyError(
                     message:

--- a/Sources/Swiftly/OutputSchema.swift
+++ b/Sources/Swiftly/OutputSchema.swift
@@ -285,7 +285,7 @@ struct InstallToolchainInfo: OutputData {
                 branch = .main
             } else if let major = branchMajor, let minor = branchMinor {
                 let branchPatch = try? versionContainer.decodeIfPresent(String.self, forKey: .patch)
-                branch = .release(major: major, minor: minor, patch: branchPatch)
+                branch = .releaseNormalized(major: major, minor: minor, patch: branchPatch)
             } else {
                 throw DecodingError.dataCorruptedError(
                     forKey: ToolchainVersionCodingKeys.branch,

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -445,7 +445,7 @@ extension SwiftlyWebsiteAPI.Components.Schemas.DevToolchainForArch {
                     message: "malformatted release branch: \"\(majorString).\(minorString)\"")
             }
             let patch = match.output.3.map(String.init)
-            branch = .release(major: major, minor: minor, patch: patch)
+            branch = .releaseNormalized(major: major, minor: minor, patch: patch)
         } else {
             branch = .main
         }
@@ -464,19 +464,6 @@ public struct DownloadNotFoundError: LocalizedError {
 
     public init(url: URL) {
         self.url = url
-    }
-}
-
-/// Returns true for branches whose `swift.org` snapshot path uses the `X.Y.x`
-/// shape rather than `X.Y`. As of writing, the 6.4 development branch is
-/// published at `/install/dev/6.4.x/...` while older release branches (6.0–6.3)
-/// remain at `/install/dev/X.Y/...`.
-private func sourceBranchNeedsXPatchSuffix(_ branch: ToolchainVersion.Snapshot.Branch) -> Bool {
-    switch branch {
-    case .release(major: 6, minor: 4, patch: nil):
-        return true
-    default:
-        return false
     }
 }
 
@@ -591,34 +578,13 @@ public struct SwiftlyHTTPClient: Sendable {
         {
         case .main:
             .init(.main)
-        case let .release(major, minor, nil) where sourceBranchNeedsXPatchSuffix(branch):
-            .init("\(major).\(minor).x")
         case let .release(major, minor, patch):
             .init("\(major).\(minor)\(patch.map { ".\($0)" } ?? "")")
         }
 
-        let devToolchains: SwiftlyWebsiteAPI.Components.Schemas.DevToolchains
-        do {
-            devToolchains = try await self.httpRequestExecutor.getSnapshotToolchains(branch: sourceBranch, platform: platformId)
-        } catch let originalError {
-            // swift.org changed url schemes and 6.4+ versions need `.x` patch suffix.
-            // For known versions which need this we request the right path based on `sourceBranch`,
-            // but just in case, if an initial lookup fails re-try with `.x` suffix if it applies.
-            guard case let .release(major, minor, nil) = branch else {
-                // We can't append an .x patch if a patch version was already specified.
-                throw originalError
-            }
-
-            // Last resort, retry with .x patch suffix
-            guard let devToolchainsPatched =
-                  try? await self.httpRequestExecutor.getSnapshotToolchains(
-                    branch: .init("\(major).\(minor).x"), platform: platformId) else {
-                // Ignore the last-resort failure, report the original failure
-                throw originalError
-            }
-
-            devToolchains = devToolchainsPatched
-        }
+        let devToolchains = try await self.httpRequestExecutor.getSnapshotToolchains(
+            branch: sourceBranch, platform: platformId
+        )
 
         let arch = a ?? cpuArch.value2
 

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -467,6 +467,19 @@ public struct DownloadNotFoundError: LocalizedError {
     }
 }
 
+/// Returns true for branches whose `swift.org` snapshot path uses the `X.Y.x`
+/// shape rather than `X.Y`. As of writing, the 6.4 development branch is
+/// published at `/install/dev/6.4.x/...` while older release branches (6.0–6.3)
+/// remain at `/install/dev/X.Y/...`.
+private func sourceBranchNeedsXPatchSuffix(_ branch: ToolchainVersion.Snapshot.Branch) -> Bool {
+    switch branch {
+    case .release(major: 6, minor: 4, patch: nil):
+        return true
+    default:
+        return false
+    }
+}
+
 /// HTTPClient wrapper used for interfacing with various REST APIs and downloading things.
 public struct SwiftlyHTTPClient: Sendable {
     public let httpRequestExecutor: HTTPRequestExecutor
@@ -578,13 +591,34 @@ public struct SwiftlyHTTPClient: Sendable {
         {
         case .main:
             .init(.main)
+        case let .release(major, minor, nil) where sourceBranchNeedsXPatchSuffix(branch):
+            .init("\(major).\(minor).x")
         case let .release(major, minor, patch):
             .init("\(major).\(minor)\(patch.map { ".\($0)" } ?? "")")
         }
 
-        let devToolchains = try await self.httpRequestExecutor.getSnapshotToolchains(
-            branch: sourceBranch, platform: platformId
-        )
+        let devToolchains: SwiftlyWebsiteAPI.Components.Schemas.DevToolchains
+        do {
+            devToolchains = try await self.httpRequestExecutor.getSnapshotToolchains(branch: sourceBranch, platform: platformId)
+        } catch let originalError {
+            // swift.org changed url schemes and 6.4+ versions need `.x` patch suffix.
+            // For known versions which need this we request the right path based on `sourceBranch`,
+            // but just in case, if an initial lookup fails re-try with `.x` suffix if it applies.
+            guard case let .release(major, minor, nil) = branch else {
+                // We can't append an .x patch if a patch version was already specified.
+                throw originalError
+            }
+
+            // Last resort, retry with .x patch suffix
+            guard let devToolchainsPatched =
+                  try? await self.httpRequestExecutor.getSnapshotToolchains(
+                    branch: .init("\(major).\(minor).x"), platform: platformId) else {
+                // Ignore the last-resort failure, report the original failure
+                throw originalError
+            }
+
+            devToolchains = devToolchainsPatched
+        }
 
         let arch = a ?? cpuArch.value2
 

--- a/Sources/SwiftlyCore/ToolchainVersion.swift
+++ b/Sources/SwiftlyCore/ToolchainVersion.swift
@@ -7,6 +7,17 @@ public enum ToolchainVersion: Sendable {
             case main
             case release(major: Int, minor: Int, patch: String? = nil)
 
+            /// Constructs a release-snapshot branch, normalizing the patch component
+            /// to match the swift.org URL scheme:
+            /// - from Swift 6.4 onward, snapshots live under `/install/dev/X.Y.x/...`,
+            /// - on older releases are passed through as-is.
+            public static func releaseNormalized(major: Int, minor: Int, patch: String?) -> Self {
+                if patch == nil, (major, minor) >= (6, 4) {
+                    return .release(major: major, minor: minor, patch: "x")
+                }
+                return .release(major: major, minor: minor, patch: patch)
+            }
+
             public var description: String {
                 switch self {
                 case .main:
@@ -145,7 +156,7 @@ public enum ToolchainVersion: Sendable {
                 throw SwiftlyError(message: "invalid release snapshot version: \(string)")
             }
             let patch = match.output.3.map(String.init)
-            self = ToolchainVersion(snapshotBranch: .release(major: major, minor: minor, patch: patch), date: String(match.output.4))
+            self = ToolchainVersion(snapshotBranch: .releaseNormalized(major: major, minor: minor, patch: patch), date: String(match.output.4))
         } else if string == "xcode" {
             self = ToolchainVersion.xcodeVersion
         } else {
@@ -477,7 +488,7 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
         }
 
         let patch = match.output.3.map(String.init)
-        return .snapshot(branch: .release(major: major, minor: minor, patch: patch), date: match.output.4.map(String.init))
+        return .snapshot(branch: .releaseNormalized(major: major, minor: minor, patch: patch), date: match.output.4.map(String.init))
     }
 }
 

--- a/Tests/SwiftlyTests/ToolchainSelectorTests.swift
+++ b/Tests/SwiftlyTests/ToolchainSelectorTests.swift
@@ -39,7 +39,7 @@ import Testing
         try runTest(.snapshot(branch: .main, date: "2023-06-05"), parses)
     }
 
-    @Test func parseReleaseSnapshot() throws {
+    @Test func parseDeprecatedReleaseSnapshot() throws {
         let parses = [
             "5.7-snapshot",
             "5.7-SNAPSHOT",
@@ -61,6 +61,35 @@ import Testing
             "swift-5.7.x-DEVELOPMENT-SNAPSHOT",
         ]
         try runTest(.snapshot(branch: .release(major: 5, minor: 7, patch: "x"), date: nil), parses)
+    }
+
+    @Test func parseReleaseSnapshot() throws {
+        let parses = [
+            "6.4-snapshot",
+            "6.4.x-snapshot",
+            "6.4-SNAPSHOT",
+            "6.4.x-SNAPSHOT",
+            "6.4-DEVELOPMENT-SNAPSHOT",
+            "6.4.x-DEVELOPMENT-SNAPSHOT",
+            "swift-6.4-snapshot",
+            "swift-6.4.x-snapshot",
+            "swift-6.4-SNAPSHOT",
+            "swift-6.4.x-SNAPSHOT",
+            "swift-6.4-DEVELOPMENT-SNAPSHOT",
+            "swift-6.4.x-DEVELOPMENT-SNAPSHOT",
+        ]
+        try runTest(.snapshot(branch: .release(major: 6, minor: 4, patch: "x"), date: nil), parses)
+    }
+
+    @Test func releaseSnapshotXDependingOnVersion() throws {
+        #expect(
+            try ToolchainSelector(parsing: "6.4-snapshot")
+                == ToolchainSelector(parsing: "6.4.x-snapshot")
+        )
+        #expect(
+            try ToolchainSelector(parsing: "5.7-snapshot")
+                != ToolchainSelector(parsing: "5.7.x-snapshot")
+        )
     }
 
     @Test func parseReleaseSnapshotWithDate() throws {


### PR DESCRIPTION
swift.org changed the url scheme and 6.4 now needs to become 6.4.x.

We should not require users to know about this and installing 6.4 or 6.4-snapshot is totally expected to work.

This fixes the known urls and also adds a fallback for the future;

Options to consider:
- we could remove the fallback... I'm just being extra careful about future i guess, perhaps too much?
- we could default all versions from 6.4 onwards to add the .x always, but that's pretty spectulative so i didn't do that.

Current scheme adds the .x for 6.4 and for others it would attempt a fallback to .x but now try it first.

Resolves https://github.com/swiftlang/swiftly/issues/560

---

before:

```
-> % swiftly install 6.4-snapshot
Fetching the latest 6.4 development branch snapshot...
-----------------------------
A new release of swiftly is available.
Please run `swiftly self-update` to update.
-----------------------------
Error: Unexpected response, expected status code: ok, response: undocumented(statusCode: 404, OpenAPIRuntime.UndocumentedPayload(headerFields: [(field: Server: Apple, next: 65535), (field: Date: Sat, 13 Jun 2026 02:43:54 GMT, next: 65535), (field: Content-Type: text/html, next: 65535), (field: Content-Length: 146, next: 65535), (field: Strict-Transport-Security: max-age=31536000; includeSubdomains, next: 65535), (field: X-Frame-Options: SAMEORIGIN, next: 65535), (field: X-XSS-Protection: 1; mode=block, next: 65535), (field: Age: 2, next: 65535), (field: Via: https/1.1 jptyo5-edge-mx-010.ts.apple.com (acdn/316.16515), https/1.1 jptyo5-edge-fx-028.ts.apple.com (acdn/316.16515), next: 65535), (field: X-Cache: hit-stale, miss, next: 65535), (field: CDNUUID: f0997761-ef15-4f9d-ac2e-03889f7307d5-156837625, next: 65535), (field: Connection: keep-alive, next: 65535)], body: Optional(OpenAPIRuntime.HTTPBody)))
```

after

```
-> % ./.build/debug/swiftly install 6.4-snapshot
Fetching the latest 6.4 development branch snapshot...
Installing 6.4.x-snapshot-2026-06-10
                                                                                                        Downloading 6.4.x-snapshot-2026-06-10
 2% [====------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------]
Downloaded 42.1 MiB of 1855.3 MiB^C
```