### PR TITLE
Fix typo in Run.swift comment

### DIFF
--- a/Sources/Swiftly/Run.swift
+++ b/Sources/Swiftly/Run.swift
@@ -69,7 +69,7 @@ struct Run: SwiftlyCommand {
             throw CleanExit.helpRequest(self)
         }
 
-        // Handle the spcific case where version is requested of the run subcommand
+        // Handle the specific case where version is requested of the run subcommand
         if command == ["--version"] {
             throw CleanExit.message(String(describing: SwiftlyCore.version))
         }


### PR DESCRIPTION
## Summary

Fix a typo in a code comment in `Sources/Swiftly/Run.swift`:

- `spcific` → `specific` (line 72)

No functional changes — comment only.