### PR TITLE
Reorder getting-started tabs to put macOS first

### DIFF
--- a/Documentation/SwiftlyDocs.docc/getting-started.md
+++ b/Documentation/SwiftlyDocs.docc/getting-started.md
@@ -5,21 +5,6 @@ Start using swiftly and Swift.
 To get started with swiftly you can download it from [swift.org](https://swift.org/download), and extract the package.
 
 @TabNavigator {
-    @Tab("Linux") {
-        If you are using Linux then you can download the binary:
-
-        ```
-        curl -L https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz > swiftly.tar.gz
-        tar zxf swiftly.tar.gz
-        ```
-
-        Now run swiftly init to finish the installation:
-
-        ```
-        ./swiftly init
-        ```
-    }
-
     @Tab("macOS") {
         On macOS you can either run the pkg installer from the command-line like this or run the package by double-clicking on it (not recommended):
 
@@ -32,6 +17,21 @@ To get started with swiftly you can download it from [swift.org](https://swift.o
 
         ```
         ~/.swiftly/bin/swiftly init
+        ```
+    }
+
+    @Tab("Linux") {
+        If you are using Linux then you can download the binary:
+
+        ```
+        curl -L https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz > swiftly.tar.gz
+        tar zxf swiftly.tar.gz
+        ```
+
+        Now run swiftly init to finish the installation:
+
+        ```
+        ./swiftly init
         ```
     }
 }


### PR DESCRIPTION
## Motivation

In the _Getting started with swiftly_ documentation, the platform installation tabs are currently ordered with Linux first, so Linux is the default tab readers see first. macOS is Swift's primary development platform, so this PR reorders the "macOS" tab ahead of the "Linux" tab, making macOS the default selected tab in the `@TabNavigator`.

## Changes

- Swapped the order of the `@Tab("macOS")` and `@Tab("Linux")` blocks in `Documentation/SwiftlyDocs.docc/getting-started.md`. No content within either tab was modified.

## Notes

- Documentation-only change; no code or tests affected.
- Followed the Swift contribution guidelines (<https://www.swift.org/contributing/>): concise title with rationale in the body, clean commit, no in-source attribution.