### PR TITLE
Add support for Ubuntu 26.04 and Debian 13

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -11,6 +11,7 @@ typealias fs = SwiftlyCore.FileSystem
 /// TODO: replace dummy implementations
 public struct Linux: Platform {
     let linuxPlatforms: [PlatformDefinition] = [
+        .ubuntu2604,
         .ubuntu2404,
         .ubuntu2204,
         .ubuntu2004,
@@ -20,6 +21,7 @@ public struct Linux: Platform {
         .rhel9,
         .amazonlinux2,
         .debian12,
+        .debian13,
     ]
 
     public init() {}
@@ -164,6 +166,28 @@ public struct Linux: Platform {
                 "tzdata",
                 "zlib1g-dev",
             ]
+        case "ubuntu2604":
+            [
+                "binutils",
+                "binutils-gold",
+                "git",
+                "unzip",
+                "zip",
+                "gnupg2",
+                "libc6-dev",
+                "libcurl4-openssl-dev",
+                "libedit2",
+                "libgcc-15-dev",
+                "libpython3-dev",
+                "libsqlite3-0",
+                "libstdc++-15-dev",
+                "libxml2-dev",
+                "libncurses-dev",
+                "libz3-dev",
+                "pkg-config",
+                "tzdata",
+                "zlib1g-dev",
+            ]
         case "amazonlinux2":
             [
                 "binutils",
@@ -237,6 +261,25 @@ public struct Linux: Platform {
                 "unzip",
                 "zip",
             ]
+        case "debian13":
+            [
+                "binutils", // binutils-gold is a virtual package that points to binutils
+                "libicu-dev",
+                "libcurl4-openssl-dev",
+                "libedit-dev",
+                "libsqlite3-dev",
+                "libncurses-dev",
+                "libpython3-dev",
+                "libxml2-dev",
+                "pkg-config",
+                "uuid-dev",
+                "tzdata",
+                "git",
+                "gcc",
+                "libstdc++-14-dev",
+                "unzip",
+                "zip",
+            ]
         default:
             []
         }
@@ -252,13 +295,15 @@ public struct Linux: Platform {
             "apt-get"
         case "ubuntu2404":
             "apt-get"
+        case "ubuntu2604":
+            "apt-get"
         case "amazonlinux2":
             "yum"
         case "ubi9":
             "dnf"
         case "fedora39", "fedora41":
             "dnf"
-        case "debian12":
+        case "debian12", "debian13":
             "apt-get"
         default:
             nil
@@ -628,7 +673,9 @@ public struct Linux: Platform {
             .ubuntu2004,
             .ubuntu2204,
             .ubuntu2404,
+            .ubuntu2604,
             .debian12,
+            .debian13,
             .fedora39,
             .fedora41,
         ].first(where: { $0.name == id + versionID }) {

--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -263,7 +263,8 @@ public struct Linux: Platform {
             ]
         case "debian13":
             [
-                "binutils", // binutils-gold is a virtual package that points to binutils
+                "binutils",
+                "binutils-gold",
                 "libicu-dev",
                 "libcurl4-openssl-dev",
                 "libedit-dev",

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -402,9 +402,17 @@ extension SwiftlyWebsiteAPI.Components.Schemas.Platform {
             PlatformDefinition(
                 name: "ubuntu2404", nameFull: "ubuntu24.04", namePretty: "Ubuntu 24.04"
             )
+        case "Ubuntu 26.04":
+            PlatformDefinition(
+                name: "ubuntu2604", nameFull: "ubuntu26.04", namePretty: "Ubuntu 26.04"
+            )
         case "Debian 12":
             PlatformDefinition(
                 name: "debian12", nameFull: "debian12", namePretty: "Debian GNU/Linux 12"
+            )
+        case "Debian 13":
+            PlatformDefinition(
+                name: "debian13", nameFull: "debian13", namePretty: "Debian GNU/Linux 13"
             )
         case "Fedora 39":
             PlatformDefinition(
@@ -554,7 +562,8 @@ public struct SwiftlyHTTPClient: Sendable {
             switch platform.name
         {
         // These are new platforms that aren't yet in the list of known platforms in the OpenAPI schema
-        case PlatformDefinition.ubuntu2404.name, PlatformDefinition.debian12.name,
+        case PlatformDefinition.ubuntu2404.name, PlatformDefinition.ubuntu2604.name,
+             PlatformDefinition.debian12.name, PlatformDefinition.debian13.name,
              PlatformDefinition.fedora39.name, PlatformDefinition.fedora41.name:
             .init(platform.name)
 

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -25,6 +25,9 @@ public struct PlatformDefinition: Codable, Equatable, Sendable {
 
     public static let macOS = PlatformDefinition(name: "xcode", nameFull: "osx", namePretty: "macOS")
 
+    public static let ubuntu2604 = PlatformDefinition(
+        name: "ubuntu2604", nameFull: "ubuntu26.04", namePretty: "Ubuntu 26.04"
+    )
     public static let ubuntu2404 = PlatformDefinition(
         name: "ubuntu2404", nameFull: "ubuntu24.04", namePretty: "Ubuntu 24.04"
     )
@@ -49,6 +52,9 @@ public struct PlatformDefinition: Codable, Equatable, Sendable {
     )
     public static let debian12 = PlatformDefinition(
         name: "debian12", nameFull: "debian12", namePretty: "Debian GNU/Linux 12"
+    )
+    public static let debian13 = PlatformDefinition(
+        name: "debian13", nameFull: "debian13", namePretty: "Debian GNU/Linux 13"
     )
 }
 

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -146,6 +146,7 @@ import Testing
         }
 
         static let macOS = ToolchainSpecifier(platform: .macOS)
+        static let ubuntu2604 = ToolchainSpecifier(platform: .ubuntu2604, branches: [.main])
         static let ubuntu2404 = ToolchainSpecifier(platform: .ubuntu2404)
         static let ubuntu2404_6_4_x = ToolchainSpecifier(
             platform: .ubuntu2404,
@@ -160,12 +161,14 @@ import Testing
         )
         static let amazonlinux2 = ToolchainSpecifier(platform: .amazonlinux2)
         static let debian12 = ToolchainSpecifier(platform: .debian12)
+        static let debian13 = ToolchainSpecifier(platform: .debian13, branches: [.main])
     }
 
     @Test(
         .tags(.large),
         arguments: [
             ToolchainSpecifier.macOS,
+            .ubuntu2604,
             .ubuntu2404,
             .ubuntu2404_6_4_x,
             .ubuntu2204,
@@ -174,6 +177,7 @@ import Testing
             .fedora41,
             .amazonlinux2,
             .debian12,
+            .debian13,
         ]
     ) func getToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
         guard case let pd = try await Swiftly.currentPlatform.detectPlatform(SwiftlyTests.ctx, disableConfirmation: true, platform: nil), pd != PlatformDefinition.rhel9 && pd != PlatformDefinition.ubuntu2004 else {

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -134,19 +134,26 @@ import Testing
         let platform: PlatformDefinition
         let architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture]
         let branches: [ToolchainVersion.Snapshot.Branch]
+        let isReleased: Bool
 
         init(
             platform: PlatformDefinition,
             architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture] = [.x8664, .aarch64],
-            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major: 6, minor: 1)]
+            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major: 6, minor: 1)],
+            isReleased: Bool = true
         ) {
             self.platform = platform
             self.architectures = architectures
             self.branches = branches
+            self.isReleased = isReleased
         }
 
         static let macOS = ToolchainSpecifier(platform: .macOS)
-        static let ubuntu2604 = ToolchainSpecifier(platform: .ubuntu2604, branches: [.main])
+        static let ubuntu2604 = ToolchainSpecifier(
+            platform: .ubuntu2604,
+            branches: [.main],
+            isReleased: false
+        )
         static let ubuntu2404 = ToolchainSpecifier(platform: .ubuntu2404)
         static let ubuntu2404_6_4_x = ToolchainSpecifier(
             platform: .ubuntu2404,
@@ -161,7 +168,11 @@ import Testing
         )
         static let amazonlinux2 = ToolchainSpecifier(platform: .amazonlinux2)
         static let debian12 = ToolchainSpecifier(platform: .debian12)
-        static let debian13 = ToolchainSpecifier(platform: .debian13, branches: [.main])
+        static let debian13 = ToolchainSpecifier(
+            platform: .debian13,
+            branches: [.main],
+            isReleased: false
+        )
     }
 
     @Test(
@@ -191,7 +202,11 @@ import Testing
         for arch in toolchainData.architectures {
             let releases = try await httpClient.getReleaseToolchains(platform: toolchainData.platform, arch: arch, limit: 5)
             // THEN: we get at least 1 release
-            #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
+            withKnownIssue("This platform has no released toolchains yet") {
+                #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
+            } when: {
+                !toolchainData.isReleased
+            }
 
             for branch in toolchainData.branches {
                 // GIVEN: we have a swiftly http client with swift.org metadata capability

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -134,26 +134,19 @@ import Testing
         let platform: PlatformDefinition
         let architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture]
         let branches: [ToolchainVersion.Snapshot.Branch]
-        let isReleased: Bool
 
         init(
             platform: PlatformDefinition,
             architectures: [SwiftlyWebsiteAPI.Components.Schemas.Architecture] = [.x8664, .aarch64],
-            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major: 6, minor: 1)],
-            isReleased: Bool = true
+            branches: [ToolchainVersion.Snapshot.Branch] = [.main, .release(major: 6, minor: 1)]
         ) {
             self.platform = platform
             self.architectures = architectures
             self.branches = branches
-            self.isReleased = isReleased
         }
 
         static let macOS = ToolchainSpecifier(platform: .macOS)
-        static let ubuntu2604 = ToolchainSpecifier(
-            platform: .ubuntu2604,
-            branches: [.main],
-            isReleased: false
-        )
+        static let ubuntu2604 = ToolchainSpecifier(platform: .ubuntu2604, branches: [.main])
         static let ubuntu2404 = ToolchainSpecifier(platform: .ubuntu2404)
         static let ubuntu2404_6_4_x = ToolchainSpecifier(
             platform: .ubuntu2404,
@@ -168,11 +161,7 @@ import Testing
         )
         static let amazonlinux2 = ToolchainSpecifier(platform: .amazonlinux2)
         static let debian12 = ToolchainSpecifier(platform: .debian12)
-        static let debian13 = ToolchainSpecifier(
-            platform: .debian13,
-            branches: [.main],
-            isReleased: false
-        )
+        static let debian13 = ToolchainSpecifier(platform: .debian13, branches: [.main])
     }
 
     @Test(
@@ -202,11 +191,7 @@ import Testing
         for arch in toolchainData.architectures {
             let releases = try await httpClient.getReleaseToolchains(platform: toolchainData.platform, arch: arch, limit: 5)
             // THEN: we get at least 1 release
-            withKnownIssue("This platform has no released toolchains yet") {
-                #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
-            } when: {
-                !toolchainData.isReleased
-            }
+            #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
 
             for branch in toolchainData.branches {
                 // GIVEN: we have a swiftly http client with swift.org metadata capability

--- a/Tests/SwiftlyTests/HTTPClientTests.swift
+++ b/Tests/SwiftlyTests/HTTPClientTests.swift
@@ -168,7 +168,6 @@ import Testing
         .tags(.large),
         arguments: [
             ToolchainSpecifier.macOS,
-            .ubuntu2604,
             .ubuntu2404,
             .ubuntu2404_6_4_x,
             .ubuntu2204,
@@ -177,9 +176,8 @@ import Testing
             .fedora41,
             .amazonlinux2,
             .debian12,
-            .debian13,
         ]
-    ) func getToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
+    ) func getReleaseToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
         guard case let pd = try await Swiftly.currentPlatform.detectPlatform(SwiftlyTests.ctx, disableConfirmation: true, platform: nil), pd != PlatformDefinition.rhel9 && pd != PlatformDefinition.ubuntu2004 else {
             return
         }
@@ -192,7 +190,34 @@ import Testing
             let releases = try await httpClient.getReleaseToolchains(platform: toolchainData.platform, arch: arch, limit: 5)
             // THEN: we get at least 1 release
             #expect(1 <= releases.count, "No releases found for \(toolchainData.platform.name): \(arch.value2)")
+        }
+    }
 
+    @Test(
+        .tags(.large),
+        arguments: [
+            ToolchainSpecifier.macOS,
+            .ubuntu2604,
+            .ubuntu2404,
+            .ubuntu2404_6_4_x,
+            .ubuntu2204,
+            .rhel9,
+            .fedora39,
+            .fedora41,
+            .amazonlinux2,
+            .debian12,
+            .debian13,
+        ]
+    ) func getSnapshotToolchainMetadataFromSwiftOrg(_ toolchainData: ToolchainSpecifier) async throws {
+        guard case let pd = try await Swiftly.currentPlatform.detectPlatform(SwiftlyTests.ctx, disableConfirmation: true, platform: nil), pd != PlatformDefinition.rhel9 && pd != PlatformDefinition.ubuntu2004 else {
+            return
+        }
+
+        let httpClient = SwiftlyHTTPClient(httpRequestExecutor: HTTPRequestExecutorImpl())
+
+        // GIVEN: we have a swiftly http client with swift.org metadata capability
+        // WHEN: we ask for the first five releases of a supported platform in a supported arch
+        for arch in toolchainData.architectures {
             for branch in toolchainData.branches {
                 // GIVEN: we have a swiftly http client with swift.org metadata capability
                 // WHEN: we ask for the first five snapshots on a branch for a supported platform and arch

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -644,8 +644,12 @@ public final actor MockToolchainDownloader: HTTPRequestExecutor {
             "Red Hat Universal Base Image 9"
         case PlatformDefinition(name: "ubuntu2404", nameFull: "ubuntu24.04", namePretty: "Ubuntu 24.04"):
             "Ubuntu 24.04"
+        case PlatformDefinition(name: "ubuntu2604", nameFull: "ubuntu26.04", namePretty: "Ubuntu 26.04"):
+            "Ubuntu 26.04"
         case PlatformDefinition(name: "debian12", nameFull: "debian12", namePretty: "Debian GNU/Linux 12"):
             "Debian 12"
+        case PlatformDefinition(name: "debian13", nameFull: "debian13", namePretty: "Debian GNU/Linux 13"):
+            "Debian 13"
         case PlatformDefinition(name: "fedora39", nameFull: "fedora39", namePretty: "Fedora Linux 39"):
             "Fedora 39"
         case PlatformDefinition(name: "fedora41", nameFull: "fedora41", namePretty: "Fedora Linux 41"):


### PR DESCRIPTION
Closes #569

Corresponding PR swiftlang/swift-org-website#1478 is required to make `swiftly install main-snapshot` work and pass the `getToolchainMetadataFromSwiftOrg` test.

I have updated the list of dependent packages, using swiftlang/swift-docker as a reference.

<details><summary>diff nightly-main/ubuntu/{24,26}.04/Dockerfile</summary>

```diff
1c1
< FROM ubuntu:24.04
---
> FROM ubuntu:resolute
7a8
>     binutils-gold \
10d10
<     unzip \
16c16
<     libgcc-13-dev \
---
>     libgcc-15-dev \
19c19
<     libstdc++-13-dev \
---
>     libstdc++-15-dev \
36c36
< ARG OS_MAJOR_VER=24
---
> ARG OS_MAJOR_VER=26
```

</details>

<details><summary>diff nightly-main/debian/{12,13}/Dockerfile</summary>

```diff
1c1
< FROM debian:12
---
> FROM debian:13
20c20
<     libstdc++-12-dev \
---
>     libstdc++-14-dev \
25,26c25,26
< ARG SWIFT_PLATFORM=debian12
< ARG SWIFT_VERSION=6.2
---
> ARG SWIFT_PLATFORM=debian13
> ARG SWIFT_VERSION=6.4
```

</details>

I didn't add both platforms to the `tests-selfhosted` and `tests-bootstrapped` CI jobs yet because there are no released Swiftly builds for them and no `swiftlang/swift:nightly-main-{debian13,resolute}` images on Docker Hub.

Other references:

- https://github.com/swiftlang/swiftly/pull/530