### PR TITLE
Set "Tool" eyebrow and align DisplayName with combined docs

### DIFF
--- a/Documentation/SwiftlyDocs.docc/SwiftlyDocs.md
+++ b/Documentation/SwiftlyDocs.docc/SwiftlyDocs.md
@@ -3,7 +3,8 @@
 Install and manage your Swift programming language toolchains.
 
 @Metadata {
-    @DisplayName("Swiftly")
+    @DisplayName("Installer (Swiftly)")
+    @TitleHeading("Tool")
 }
 
 Swiftly helps you to easily install different Swift toolchains locally on your account.


### PR DESCRIPTION
## Summary
- Adds `@TitleHeading("Tool")` to the `SwiftlyDocs` root page, so the page shows a "Tool" eyebrow above its title.
- Updates `@DisplayName` from "Swiftly" to "Installer (Swiftly)" to match the label already used for this catalog in the combined Swift.org documentation's "Tools" navigation group.