### PR TITLE
Preparing Swiftly 1.2 Release Candidate

### DIFF
--- a/Sources/SwiftlyCore/SwiftlyCore.swift
+++ b/Sources/SwiftlyCore/SwiftlyCore.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftlyWebsiteAPI
 import SystemPackage
 
-public let version = SwiftlyVersion(major: 1, minor: 2, patch: 0)
+public let version = SwiftlyVersion(major: 1, minor: 2, patch: 0, suffix: "dev")
 
 /// Protocol defining a handler for information swiftly intends to print to stdout.
 /// This is currently only used to intercept print statements for testing.


### PR DESCRIPTION
Adding the `-dev` back in for a release-candidate spin and for a commit to tag the release candidate off of.