### PR TITLE
Propagate verbose flag to running the macOS installer

### DIFF
--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -100,7 +100,7 @@ public struct MacOS: Platform {
             // If the toolchains go into the default user location then we use the installer to install them
             await ctx.message("Installing package in user home directory...")
 
-            try await sys.installer(.verbose, .pkg(tmpFile), .target("CurrentUserHomeDirectory")).run()
+            try await sys.installer(.verbose, .pkg(tmpFile), .target("CurrentUserHomeDirectory")).run(quiet: !verbose)
         } else {
             // Otherwise, we extract the pkg into the requested toolchains directory.
             await ctx.message("Expanding pkg...")


### PR DESCRIPTION
Installing a swift toolchain in the standard location for macOS has a very verbose installer output when verbose output isn't requested by the user.

Pass the verbose flag down to the run() method's quiet to squelch stdout/stderr when verbose output isn't requested.