### PR TITLE
1.2🍒: Init: Improve resilience on new platforms

### DIFF
--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -345,8 +345,35 @@ struct Init: SwiftlyCommand {
         var pathChanged = false
 
         if !skipInstall {
-            let latestVersion = try await Install.resolve(ctx, config: config, selector: ToolchainSelector.latest)
-            (postInstall, pathChanged) = try await Install.execute(ctx, version: latestVersion, &config, useInstalledToolchain: true, verifySignature: true, verbose: verbose, assumeYes: assumeYes)
+            let installVersion: ToolchainVersion?
+            do {
+                installVersion = try await Install.resolve(ctx, config: config, selector: ToolchainSelector.latest)
+            } catch let error as ResolveError {
+                guard error.reason == .noRelease else { throw error }
+
+                await ctx.printError("Warning: no release toolchain available for this distribution.")
+                let installMainSnapshot: Bool
+                if assumeYes {
+                    installMainSnapshot = true
+                } else {
+                    await ctx.printError("Install main-snapshot toolchain?")
+                    installMainSnapshot = await ctx.promptForConfirmation(defaultBehavior: true)
+                }
+
+                if installMainSnapshot {
+                    installVersion = try await Install.resolve(
+                        ctx,
+                        config: config,
+                        selector: ToolchainSelector.snapshot(branch: .main, date: nil)
+                    )
+                } else {
+                    installVersion = nil
+                }
+            }
+
+            if let installVersion {
+                (postInstall, pathChanged) = try await Install.execute(ctx, version: installVersion, &config, useInstalledToolchain: true, verifySignature: true, verbose: verbose, assumeYes: assumeYes)
+            }
         }
 
         if !quietShellFollowup {

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -451,16 +451,13 @@ struct Install: SwiftlyCommand {
                     platform: config.platform, limit: 1
                 ).first
             else {
-                throw SwiftlyError(message: "couldn't get latest releases")
+                throw ResolveError(reason: .noRelease, selector: selector)
             }
             return .stable(release)
 
         case let .stable(major, minor, patch):
             guard let minor else {
-                throw SwiftlyError(
-                    message:
-                    "Need to provide at least major and minor versions when installing a release toolchain."
-                )
+                throw ResolveError(reason: .badSelector, selector: selector)
             }
 
             if let patch {
@@ -478,7 +475,7 @@ struct Install: SwiftlyCommand {
             }.first
 
             guard let toolchain else {
-                throw SwiftlyError(message: "No release toolchain found matching \(major).\(minor)")
+                throw ResolveError(reason: .noRelease, selector: selector)
             }
 
             return .stable(toolchain)
@@ -500,10 +497,7 @@ struct Install: SwiftlyCommand {
                     snapshot.branch == branch
                 }
             } catch let branchNotFoundErr as SwiftlyHTTPClient.SnapshotBranchNotFoundError {
-                throw SwiftlyError(
-                    message:
-                    "You have requested to install a snapshot toolchain from branch \(branchNotFoundErr.branch). It cannot be found on swift.org. Note that snapshots are only available from the current `main` release and the latest x.y (major.minor) release. Try again with a different branch."
-                )
+                throw ResolveError(reason: .badSelector, selector: selector)
             } catch {
                 throw error
             }
@@ -511,12 +505,57 @@ struct Install: SwiftlyCommand {
             let firstSnapshot = snapshots.first
 
             guard let firstSnapshot else {
-                throw SwiftlyError(message: "No snapshot toolchain found for branch \(branch)")
+                throw ResolveError(reason: .noRelease, selector: selector)
             }
 
             return .snapshot(firstSnapshot)
         case .xcode:
             return .xcode
+        }
+    }
+}
+
+struct ResolveError: LocalizedError, CustomStringConvertible {
+    enum Reason {
+        case badSelector
+        case noRelease
+    }
+
+    init(reason: Reason, selector: ToolchainSelector) {
+        self.reason = reason
+        self.requestedSelector = selector
+    }
+
+    let reason: Reason
+    let requestedSelector: ToolchainSelector
+
+    public var errorDescription: String { self.message }
+    public var description: String { self.message }
+
+    public var message: String {
+        switch self.reason {
+        case .badSelector:
+            switch self.requestedSelector {
+            case .latest:
+                fatalError("Unhandled 'latest' selector resolution error")
+            case let .stable:
+                return "Need to provide at least major and minor version when installing a release toolchain."
+            case let .snapshot(branch, _):
+                return "You have requested to install a snapshot toolchain from \(branch). It cannot be found on swift.org. Note that snapshots are only available from the current `main` release and the latest x.y (major.minor) release. Try againt with a different branch."
+            case .xcode:
+                fatalError("Unhandled Xcode selector resolution error")
+            }
+        case .noRelease:
+            switch self.requestedSelector {
+            case .latest:
+                return "couldn't get latest releases"
+            case let .stable(major, minor, _):
+                return "No release toolchain found matching \(major).\(minor)"
+            case let .snapshot(branch, _):
+                return "No snapshot toolchain found for branch \(branch)"
+            case .xcode:
+                fatalError("Unhandled no release xcode toolchain error")
+            }
         }
     }
 }

--- a/Tests/SwiftlyTests/InitTests.swift
+++ b/Tests/SwiftlyTests/InitTests.swift
@@ -123,4 +123,55 @@ import Testing
         #expect(try await fs.exists(atPath: Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx) / "foo.txt"))
         #expect(try await fs.exists(atPath: Swiftly.currentPlatform.swiftlyToolchainsDir(SwiftlyTests.ctx) / "foo.txt"))
     }
+
+    @Test(.testHome()) func initNoReleaseFallsBackToMainSnapshot() async throws {
+        // GIVEN: a fresh account on a distribution with no release toolchain available
+        try? await fs.remove(atPath: Swiftly.currentPlatform.swiftlyConfigFile(SwiftlyTests.ctx))
+
+        var ctx = SwiftlyTests.ctx
+        // ctx.mockedShell = "/bin/bash"
+        ctx.httpClient = SwiftlyHTTPClient(
+            httpRequestExecutor: MockToolchainDownloader(executables: [], releaseToolchains: []))
+
+        try await SwiftlyTests.$ctx.withValue(ctx) {
+            // WHEN: init runs without --skip-install and auto-confirms
+            _ = try await SwiftlyTests.runWithMockedIO(Init.self, ["init", "--assume-yes"])
+
+            // THEN: init completes and falls back to installing a main snapshot
+            let config = try await Config.load()
+            #expect(SwiftlyCore.version == config.version)
+            #expect(!config.installedToolchains.isEmpty)
+            let installed = config.installedToolchains.first
+            guard let installed,
+                  case let .snapshot(snapshot) = installed,
+                  snapshot.branch == .main
+            else {
+                Issue.record("expected a main snapshot to be installed, got \(String(describing: installed))")
+                return
+            }
+            // AND: the only installed toolchain becomes the global default
+            #expect(config.inUse == installed)
+        }
+    }
+
+    @Test(.testHome()) func initNoReleaseDeclineSnapshot() async throws {
+        // GIVEN: a fresh account on a distribution with no release toolchain available
+        try? await fs.remove(atPath: Swiftly.currentPlatform.swiftlyConfigFile(SwiftlyTests.ctx))
+
+        var ctx = SwiftlyTests.ctx
+        ctx.httpClient = SwiftlyHTTPClient(
+            httpRequestExecutor: MockToolchainDownloader(executables: [], releaseToolchains: []))
+
+        try await SwiftlyTests.$ctx.withValue(ctx) {
+            // WHEN: init runs interactively, confirming the welcome prompt ("y") but
+            // declining the main-snapshot fallback prompt ("n")
+            _ = try await SwiftlyTests.runWithMockedIO(Init.self, ["init"], input: ["y", "n"])
+
+            // THEN: swiftly is still initialized, but no toolchain was installed
+            let config = try await Config.load()
+            #expect(SwiftlyCore.version == config.version)
+            #expect(config.installedToolchains.isEmpty)
+            #expect(config.inUse == nil)
+        }
+    }
 }


### PR DESCRIPTION
Swiftly init on platforms that don't have a release toolchain would fail and leave Swiftly in an inconsistent state. This is a quick patch to fall back on a `main-snapshot` toolchain if the latest toolchain doesn't exist.

Init will still attempt to find the latest toolchain, but if no latest toolchain exists, it will emit a warning saying so, and ask the user if they want to install a new toolchain. If they decline, swiftly will continue with the swiftly installation, but not attempt to install anything.

To make the code a little more resilient and target only cases where Swiftly failed to resolve a toolchain, I've added a new `ResolveError` type that tracks the reason for the failure and what the requested Toolchain selector was. That is used to construct the error message or to extract info about what failed.

Added tests to verify the behavior when the main snapshot install is accepted and rejected, verifying that we install the snapshot or continue to not have any installed toolchains.

(cherry picked from commit 198fc236ac18d7922451e87b3934db3533ad9b6a)
Cherry-Pick PR: https://github.com/swiftlang/swiftly/pull/587