### PR TITLE
Fix command expansion in env.sh

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -46,6 +46,11 @@ public struct Linux: Platform {
             ?? fs.home / ".local/share/swiftly/toolchains"
     }
 
+    public func escapePathForShell(_ path: FilePath) -> String {
+        let escaped = String(decoding: path).replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
     public var toolchainFileExtension: String {
         "tar.gz"
     }

--- a/Sources/MacOSPlatform/MacOS.swift
+++ b/Sources/MacOSPlatform/MacOS.swift
@@ -41,6 +41,11 @@ public struct MacOS: Platform {
             ?? self.defaultToolchainsDirectory
     }
 
+    public func escapePathForShell(_ path: FilePath) -> String {
+        let escaped = String(decoding: path).replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
     public var toolchainFileExtension: String {
         "pkg"
     }

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -77,11 +77,11 @@ struct Init: SwiftlyCommand {
 
         var config = try? await Config.load(ctx)
 
-        func oldEnvSh(_ ctx: SwiftlyCoreContext) -> String {
+        func oldEnvSh2(_: SwiftlyCoreContext) -> String {
             """
-            export SWIFTLY_HOME_DIR="\(Swiftly.currentPlatform.swiftlyHomeDir(ctx))"
-            export SWIFTLY_BIN_DIR="\(Swiftly.currentPlatform.swiftlyBinDir(ctx))"
-            export SWIFTLY_TOOLCHAINS_DIR="\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
+            export SWIFTLY_HOME_DIR="\(homeDirRaw)"
+            export SWIFTLY_BIN_DIR="\(binDirRaw)"
+            export SWIFTLY_TOOLCHAINS_DIR="\(toolchainsDirRaw)"
             if [[ ":$PATH:" != *":$SWIFTLY_BIN_DIR:"* ]]; then
                 export PATH="$SWIFTLY_BIN_DIR:$PATH"
             fi
@@ -89,11 +89,11 @@ struct Init: SwiftlyCommand {
             """
         }
 
-        func oldEnvFish(_ ctx: SwiftlyCoreContext) -> String {
+        func oldEnvFish2(_: SwiftlyCoreContext) -> String {
             """
-            set -x SWIFTLY_HOME_DIR "\(Swiftly.currentPlatform.swiftlyHomeDir(ctx))"
-            set -x SWIFTLY_BIN_DIR "\(Swiftly.currentPlatform.swiftlyBinDir(ctx))"
-            set -x SWIFTLY_TOOLCHAINS_DIR "\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
+            set -x SWIFTLY_HOME_DIR "\(homeDirRaw)"
+            set -x SWIFTLY_BIN_DIR "\(binDirRaw)"
+            set -x SWIFTLY_TOOLCHAINS_DIR "\(toolchainsDirRaw)"
             if not contains "$SWIFTLY_BIN_DIR" $PATH
                 set -x PATH "$SWIFTLY_BIN_DIR" $PATH
             end
@@ -101,7 +101,36 @@ struct Init: SwiftlyCommand {
             """
         }
 
-        func envSh(_ ctx: SwiftlyCoreContext) -> String {
+        func oldEnvSh(_: SwiftlyCoreContext) -> String {
+            """
+            export SWIFTLY_HOME_DIR="\(homeDirRaw)"
+            export SWIFTLY_BIN_DIR="\(binDirRaw)"
+            export SWIFTLY_TOOLCHAINS_DIR="\(toolchainsDirRaw)"
+
+            # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+            PATH="${PATH//:$SWIFTLY_BIN_DIR/}"
+            PATH="${PATH/#$SWIFTLY_BIN_DIR:/}"
+            export PATH="$SWIFTLY_BIN_DIR:$PATH"
+
+            """
+        }
+
+        func oldEnvFish(_: SwiftlyCoreContext) -> String {
+            """
+            set -x SWIFTLY_HOME_DIR "\(homeDirRaw)"
+            set -x SWIFTLY_BIN_DIR "\(binDirRaw)"
+            set -x SWIFTLY_TOOLCHAINS_DIR "\(toolchainsDirRaw)"
+
+            # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+            while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)
+                set -e PATH[$index]
+            end
+            set -x PATH "$SWIFTLY_BIN_DIR" $PATH
+
+            """
+        }
+
+        func envSh(_: SwiftlyCoreContext) -> String {
             """
             export SWIFTLY_HOME_DIR=\(homeDir)
             export SWIFTLY_BIN_DIR=\(binDir)
@@ -115,7 +144,7 @@ struct Init: SwiftlyCommand {
             """
         }
 
-        func envFish(_ ctx: SwiftlyCoreContext) -> String {
+        func envFish(_: SwiftlyCoreContext) -> String {
             """
             set -x SWIFTLY_HOME_DIR \(homeDir)
             set -x SWIFTLY_BIN_DIR \(binDir)
@@ -140,7 +169,7 @@ struct Init: SwiftlyCommand {
             if case let envFile = (Swiftly.currentPlatform.swiftlyHomeDir(ctx)) / "env.sh",
                (try? await fs.exists(atPath: envFile)) ?? false,
                let contents = String(data: (try? await fs.cat(atPath: envFile)) ?? Data(), encoding: .utf8),
-               contents == oldEnvSh(ctx)
+               contents == oldEnvSh(ctx) || contents == oldEnvSh2(ctx)
             {
                 await ctx.print("Updating shell environment \(envFile)")
                 try Data(envSh(ctx).utf8).write(to: envFile, options: .atomic)
@@ -150,7 +179,7 @@ struct Init: SwiftlyCommand {
             if case let envFile = (Swiftly.currentPlatform.swiftlyHomeDir(ctx)) / "env.fish",
                (try? await fs.exists(atPath: envFile)) ?? false,
                let contents = String(data: (try? await fs.cat(atPath: envFile)) ?? Data(), encoding: .utf8),
-               contents == oldEnvFish(ctx)
+               contents == oldEnvFish(ctx) || contents == oldEnvFish2(ctx)
             {
                 await ctx.print("Updating fish shell environment \(envFile)")
                 try Data(envFish(ctx).utf8).write(to: envFile, options: .atomic)
@@ -248,14 +277,14 @@ struct Init: SwiftlyCommand {
             sourceLine = """
 
             # Added by swiftly
-            source "\(envFile)"
+            source \(Swiftly.currentPlatform.escapePathForShell(envFile))
             """
         } else {
             envFile = Swiftly.currentPlatform.swiftlyHomeDir(ctx) / "env.sh"
             sourceLine = """
 
             # Added by swiftly
-            . "\(envFile)"
+            . \(Swiftly.currentPlatform.escapePathForShell(envFile))
             """
         }
 

--- a/Sources/Swiftly/Init.swift
+++ b/Sources/Swiftly/Init.swift
@@ -67,6 +67,14 @@ struct Init: SwiftlyCommand {
     static func execute(_ ctx: SwiftlyCoreContext, assumeYes: Bool, noModifyProfile: Bool, overwrite: Bool, platform: String?, verbose: Bool, skipInstall: Bool, quietShellFollowup: Bool) async throws {
         try await Swiftly.currentPlatform.verifySwiftlySystemPrerequisites()
 
+        let homeDirRaw = Swiftly.currentPlatform.swiftlyHomeDir(ctx)
+        let binDirRaw = Swiftly.currentPlatform.swiftlyBinDir(ctx)
+        let toolchainsDirRaw = Swiftly.currentPlatform.swiftlyToolchainsDir(ctx)
+
+        let homeDir = Swiftly.currentPlatform.escapePathForShell(homeDirRaw)
+        let binDir = Swiftly.currentPlatform.escapePathForShell(binDirRaw)
+        let toolchainsDir = Swiftly.currentPlatform.escapePathForShell(toolchainsDirRaw)
+
         var config = try? await Config.load(ctx)
 
         func oldEnvSh(_ ctx: SwiftlyCoreContext) -> String {
@@ -95,9 +103,9 @@ struct Init: SwiftlyCommand {
 
         func envSh(_ ctx: SwiftlyCoreContext) -> String {
             """
-            export SWIFTLY_HOME_DIR="\(Swiftly.currentPlatform.swiftlyHomeDir(ctx))"
-            export SWIFTLY_BIN_DIR="\(Swiftly.currentPlatform.swiftlyBinDir(ctx))"
-            export SWIFTLY_TOOLCHAINS_DIR="\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
+            export SWIFTLY_HOME_DIR=\(homeDir)
+            export SWIFTLY_BIN_DIR=\(binDir)
+            export SWIFTLY_TOOLCHAINS_DIR=\(toolchainsDir)
 
             # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
             PATH="${PATH//:$SWIFTLY_BIN_DIR/}"
@@ -109,9 +117,9 @@ struct Init: SwiftlyCommand {
 
         func envFish(_ ctx: SwiftlyCoreContext) -> String {
             """
-            set -x SWIFTLY_HOME_DIR "\(Swiftly.currentPlatform.swiftlyHomeDir(ctx))"
-            set -x SWIFTLY_BIN_DIR "\(Swiftly.currentPlatform.swiftlyBinDir(ctx))"
-            set -x SWIFTLY_TOOLCHAINS_DIR "\(Swiftly.currentPlatform.swiftlyToolchainsDir(ctx))"
+            set -x SWIFTLY_HOME_DIR \(homeDir)
+            set -x SWIFTLY_BIN_DIR \(binDir)
+            set -x SWIFTLY_TOOLCHAINS_DIR \(toolchainsDir)
 
             # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
             while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -84,6 +84,9 @@ public protocol Platform: Sendable {
     /// The "toolchains" subdirectory that contains the Swift toolchains managed by swiftly.
     func swiftlyToolchainsDir(_ ctx: SwiftlyCoreContext) -> FilePath
 
+    /// Convert a FilePath object to a shell-escaped string
+    func escapePathForShell(_ path: FilePath) -> String
+
     /// The file extension of the downloaded toolchain for this platform.
     /// e.g. for Linux systems this is "tar.gz" and on macOS it's "pkg".
     var toolchainFileExtension: String { get }

--- a/Tests/SwiftlyTests/InitTests.swift
+++ b/Tests/SwiftlyTests/InitTests.swift
@@ -174,4 +174,160 @@ import Testing
             #expect(config.inUse == nil)
         }
     }
+
+    private func posixSingleQuoted(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    @Test(
+        .testHome("inject-a'$(touch PWNED)`id`;x"),
+        arguments: ["/bin/zsh", "/bin/bash", "/bin/fish"],
+        // arguments: ["/bin/bash", "/bin/zsh", "/bin/fish"],
+    ) func initEnvShEscape(shell: String) async throws {
+        // GIVEN: a fresh account whose swiftly home path contains shell metacharacters
+
+        try? await fs.remove(atPath: Swiftly.currentPlatform.swiftlyConfigFile(SwiftlyTests.ctx))
+        var ctx = SwiftlyTests.ctx
+        ctx.mockedShell = shell
+
+        let envFilename = shell.hasSuffix("fish") ? "env.fish" : "env.sh"
+
+        try await SwiftlyTests.$ctx.withValue(ctx) {
+            // WHEN: swiftly init generates env.sh
+            try await SwiftlyTests.runCommand(Init.self, ["init", "--assume-yes", "--skip-install"])
+
+            let envScript = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx) / envFilename
+            #expect(try await fs.exists(atPath: envScript))
+            let contents = try String(contentsOf: envScript)
+
+            // THEN: every SWIFTLY_* export writes the path as a fully single-quoted,
+            // escaped literal — no metacharacter can break out of the quoting.
+            let home = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx).string
+            let bin = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx).string
+            let toolchains = Swiftly.currentPlatform.swiftlyToolchainsDir(SwiftlyTests.ctx).string
+
+            #expect(contents.contains("\(self.posixSingleQuoted(home))"))
+            #expect(contents.contains("\(self.posixSingleQuoted(bin))"))
+            #expect(contents.contains("\(self.posixSingleQuoted(toolchains))"))
+
+            #expect(!contents.contains("\(home)"))
+            #expect(!contents.contains("\(toolchains)"))
+        }
+    }
+
+    @Test(
+        .testHome(),
+        arguments: [
+            ("bash", 0),
+            ("bash", 1),
+            ("fish", 0),
+            ("fish", 1),
+        ]
+    )
+    func initUpgrade(_ shell: String, _ envVersion: Int) async throws {
+        let homeDirRaw = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx).string
+        let binDirRaw = Swiftly.currentPlatform.swiftlyBinDir(SwiftlyTests.ctx).string
+        let toolchainsDirRaw = Swiftly.currentPlatform.swiftlyToolchainsDir(SwiftlyTests.ctx).string
+
+        // Create a fresh account and install an older Swiftly env.sh
+        let versions: [String: [String]] = [
+            "fish": [
+                // old, but not quite as old format
+                """
+                set -x SWIFTLY_HOME_DIR "\(homeDirRaw)"
+                set -x SWIFTLY_BIN_DIR "\(binDirRaw)"
+                set -x SWIFTLY_TOOLCHAINS_DIR "\(toolchainsDirRaw)"
+
+                # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+                while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)
+                    set -e PATH[$index]
+                end
+                set -x PATH "$SWIFTLY_BIN_DIR" $PATH
+
+                """,
+                // Old old format
+                """
+                set -x SWIFTLY_HOME_DIR "\(homeDirRaw)"
+                set -x SWIFTLY_BIN_DIR "\(binDirRaw)"
+                set -x SWIFTLY_TOOLCHAINS_DIR "\(toolchainsDirRaw)"
+                if not contains "$SWIFTLY_BIN_DIR" $PATH
+                    set -x PATH "$SWIFTLY_BIN_DIR" $PATH
+                end
+
+                """,
+            ],
+            "bash": [
+                """
+                export SWIFTLY_HOME_DIR="\(homeDirRaw)"
+                export SWIFTLY_BIN_DIR="\(binDirRaw)"
+                export SWIFTLY_TOOLCHAINS_DIR="\(toolchainsDirRaw)"
+                if [[ ":$PATH:" != *":$SWIFTLY_BIN_DIR:"* ]]; then
+                    export PATH="$SWIFTLY_BIN_DIR:$PATH"
+                fi
+
+                """,
+                """
+                export SWIFTLY_HOME_DIR="\(homeDirRaw)"
+                export SWIFTLY_BIN_DIR="\(binDirRaw)"
+                export SWIFTLY_TOOLCHAINS_DIR="\(toolchainsDirRaw)"
+
+                # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+                PATH="${PATH//:$SWIFTLY_BIN_DIR/}"
+                PATH="${PATH/#$SWIFTLY_BIN_DIR:/}"
+                export PATH="$SWIFTLY_BIN_DIR:$PATH"
+
+                """,
+            ],
+        ]
+
+        // GIVEN: an older swiftly install whose config version is migratable, and an
+        // env file written in one of the recognized old formats.
+        var config = try await Config.load()
+        config.version = try SwiftlyVersion(parsing: "1.0.0")
+        try config.save()
+
+        let envFilename = shell == "fish" ? "env.fish" : "env.sh"
+        let envFile = Swiftly.currentPlatform.swiftlyHomeDir(SwiftlyTests.ctx) / envFilename
+        let oldContents = versions[shell]![envVersion]
+        try oldContents.write(to: envFile, atomically: true, encoding: .utf8)
+        #expect(try String(contentsOf: envFile) == oldContents)
+
+        // WHEN: swiftly init runs without --overwrite, taking the upgrade path
+        try await SwiftlyTests.runCommand(Init.self, ["init", "--assume-yes", "--skip-install"])
+
+        // THEN: the env file is rewritten to the current, shell-escaped format
+        let expected: String
+        if shell == "fish" {
+            expected = """
+            set -x SWIFTLY_HOME_DIR \(self.posixSingleQuoted(homeDirRaw))
+            set -x SWIFTLY_BIN_DIR \(self.posixSingleQuoted(binDirRaw))
+            set -x SWIFTLY_TOOLCHAINS_DIR \(self.posixSingleQuoted(toolchainsDirRaw))
+
+            # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+            while set -l index (contains -i "$SWIFTLY_BIN_DIR" $PATH)
+                set -e PATH[$index]
+            end
+            set -x PATH "$SWIFTLY_BIN_DIR" $PATH
+
+            """
+        } else {
+            expected = """
+            export SWIFTLY_HOME_DIR=\(self.posixSingleQuoted(homeDirRaw))
+            export SWIFTLY_BIN_DIR=\(self.posixSingleQuoted(binDirRaw))
+            export SWIFTLY_TOOLCHAINS_DIR=\(self.posixSingleQuoted(toolchainsDirRaw))
+
+            # Remove SWIFTLY_BIN_DIR from PATH if present, then prepend it
+            PATH="${PATH//:$SWIFTLY_BIN_DIR/}"
+            PATH="${PATH/#$SWIFTLY_BIN_DIR:/}"
+            export PATH="$SWIFTLY_BIN_DIR:$PATH"
+
+            """
+        }
+
+        #expect(try String(contentsOf: envFile) == expected)
+
+        // AND: the config version is bumped to the current swiftly version
+        config = try await Config.load()
+        #expect(config.version == SwiftlyCore.version)
+    }
 }


### PR DESCRIPTION
Swiftly copies the contents of the `SWIFTLY_HOME_DIR`, `SWIFTLY_BIN_DIR`, and `SWIFTLY_TOOLCHAINS_DIR` environment variables into the generated `env.sh` file. If these environment variables contain a command, the command is executed.

This changes Swiftly to use single-quotes, preventing variable expansions and command execution when sourcing the env.sh. Also changes Swiftly to escape single quotes in the environment variable to prevent ending the single-quoted string and passing arbitrary outputs.

Thank you, Alan for reporting this issue.